### PR TITLE
feat(tracing,metrics,init,config,docs,tests): add startMode & getSpan; dual decorator support; safer lazy label handling; exporter/processor precedence; feature flags; traceOnlyIf; docs updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Typecheck & Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install (CI)
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/coverage-summary.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,19 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-      - run: npm install
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run test
       - run: npm run build
+
+      - name: Verify package version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Package version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
       - run: |
           echo @brokerize:https://registry.npmjs.org > .npmrc
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 prisma/generated
 src/buildData.json
 tempo-data
+coverage
+.vitest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # @brokerize/telemetry
 
-A TypeScript package for integrating metrics and tracing into your applications, leveraging OpenTelemetry for standardized observability.
+[![CI](https://github.com/brokerize/telemetry-js/actions/workflows/ci.yml/badge.svg)](https://github.com/brokerize/telemetry-js/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@brokerize/telemetry.svg)](https://www.npmjs.com/package/@brokerize/telemetry)
+
+A TypeScript package for integrating **metrics** and **tracing** into your applications, leveraging OpenTelemetry for standardized observability.
 
 ## Overview
 
-The `@brokerize/telemetry` package provides tools to monitor application performance and behavior through **metrics** (for numerical data like counters, gauges, histograms, and summaries) and **tracing** (for tracking request flows across distributed systems). It simplifies instrumentation with annotation-based and manual approaches, making it easy to integrate into existing TypeScript projects.
+`@brokerize/telemetry` provides tools to monitor application performance and behavior via **metrics** (counters, gauges, histograms, summaries) and **tracing** (spans across distributed systems). It simplifies instrumentation with decorator-based and manual APIs, making it easy to adopt incrementally in TypeScript projects.
 
 ## Getting Started
 
@@ -18,107 +21,322 @@ npm install @brokerize/telemetry
 
 ### Initialization
 
-Before using metrics or tracing, initialize the OpenTelemetry instrumentation with the `initInstrumentation` function. This sets up the exporter for sending telemetry data to an OpenTelemetry collector.
+Initialize OpenTelemetry with `initInstrumentation`. This sets up the context manager, exporter/processors, and optional auto-instrumentations.
 
-```typescript
+```ts
 import { initInstrumentation } from '@brokerize/telemetry';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 
 initInstrumentation({
-    serviceName: 'my-service',
-    url: 'http://your-otel-collector:4318/v1/traces',
-    localDebugging: false,
-    instrumentations: [new HttpInstrumentation()]
+  serviceName: 'my-service',
+  instrumentations: [new HttpInstrumentation()],
+
+  // (Optional) Global behavior for withTracing:
+  tracingMode: 'natural-sync-async', // or 'legacy-always-promise' (deprecated)
+
+  // (Optional) Span limits (passing this also enables span limits)
+  // spanLimits: { attributeValueLengthLimit: 12000, attributeCountLimit: 128, ... }
+
+  // ── Exporter/Processor configuration ────────────────────────────────────────
+  // EITHER: provide an exporter descriptor (simple path; library creates a BatchSpanProcessor)
+  exporter: { kind: 'otlp', url: 'http://your-otel-collector:4318/v1/traces' },
+  // exporter: { kind: 'console' } // for local debugging
+  // exporter: { kind: 'noop' }    // no-op exporting
+
+  // OR: provide your own processors (full control; library will NOT add any by itself)
+  // spanProcessors: [
+  //   new BatchSpanProcessor(new OTLPTraceExporter({ url: 'http://your-otel-collector:4318/v1/traces' })),
+  // ],
 });
 ```
 
-> **Note**: Call `initInstrumentation` at the start of your application, e.g., in an `instrumentation.ts` file. See [Initializing Instrumentation](./docs/telemetry/tracing.md#initializing-instrumentation) for more details.]
+> **Note:** Call `initInstrumentation` **once at application startup** (e.g., in `instrumentation.ts` or your entry file) **before** using any metrics or tracing APIs.
+
+### Exporter & Span Processor Precedence
+
+You can configure exporting in two ways. The library follows these rules:
+
+1. **You provide `spanProcessors`** → *Your processors are used as-is.* The library will **not** attach any exporter or default processor.
+2. **You do not provide `spanProcessors`** but provide an **`exporter`** → The library creates a **`BatchSpanProcessor(exporter)`** for you (except for `noop`, which results in no processors).
+3. **You provide neither** → Tracing runs with **no exporter** (no-op).
+
+> **Legacy compatibility:** You can still pass `url` (OTLP) and/or `localDebugging: true` (console) instead of `exporter`. These are deprecated and mapped internally to the exporter descriptor. Prefer `exporter: { kind: ... }` going forward.
 
 ## Key Features
 
 ### Metrics
 
-The `Metrics` class and `metrics` wrapper allow you to create and manage metrics such as counters, gauges, histograms, and summaries. Use annotations for automatic metric creation or manual methods for fine-grained control.
+The `Metrics` class and the `metrics` helper expose counters, gauges, histograms, and summaries. Use decorators for automatic metric recording, or call the API directly for fine-grained control. Lazy creation is preserved—metrics are instantiated on the first real measurement.
 
-#### Example: Using Annotations
+#### Decorator Compatibility (TC39 + legacy)
 
-```typescript
+The metrics decorators (`@Metrics.counter`, `@Metrics.gauge`, `@Metrics.histogram`, `@Metrics.summary`) support both the **TC39 decorator signature** `(value, ctx)` for `method/getter/setter/field/auto-accessor`, and the **legacy TypeScript decorator** signature `(target, key, descriptor)`. Use either style based on your TypeScript configuration.
+
+#### Example: Using Decorators
+
+```ts
 import { Metrics } from '@brokerize/telemetry';
 
 class ExampleService {
-    @Metrics.counter({
-        metricName: 'http_requests_total',
-        help: 'Total number of HTTP requests',
-        labels: { method: 'GET' }
-    })
-    handleRequest() {
-        // Implementation
-    }
+  @Metrics.counter({
+    metricName: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labels: { method: 'GET' },
+  })
+  handleRequest() {
+    // Implementation
+  }
 }
 ```
 
 #### Example: Manual Metric Creation
 
-```typescript
+```ts
 import { metrics, MetricType } from '@brokerize/telemetry';
 
 metrics.createMetric(MetricType.Counter, {
-    name: 'http_requests_total',
-    help: 'Total number of HTTP requests',
-    labelNames: ['method', 'status']
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'status'],
 });
 
+// Instance is lazily created on first measurement:
 metrics.incrementCounter('http_requests_total', { method: 'GET', status: '200' });
 ```
 
-For detailed usage, see [Metrics](./docs/telemetry/metrics.md).
+For detailed usage, see `./docs/telemetry/metrics.md`.
 
 ### Tracing
 
-The `Traces` class enables tracing of operations using OpenTelemetry spans. Use the `@Trace` annotation for automatic span creation or manual methods for custom tracing logic.
+The `Traces` class enables tracing of operations using OpenTelemetry spans. Use the `@Traces.trace` decorator for automatic span creation, or call helper APIs for custom logic.
 
-#### Example: Using Annotations
+#### Decorator Compatibility (TC39 + legacy)
 
-```typescript
+`@Traces.trace` supports both the **TC39 decorator signature** `(value, ctx)` for `method/getter/setter/field/auto-accessor`, and the **legacy TypeScript decorator** signature `(target, key, descriptor)`. Sync/async semantics and `this` binding are preserved across both paths.
+
+#### Start Modes (New)
+
+A **Start Mode** defines how a span is created relative to the active context:
+
+- `'reuse'` – Reuse the current active span if present; otherwise create a new one.
+- `'createChild'` – Always create a new span; it will be a child if a parent is active, otherwise a root span.
+- `'newTrace'` – Always create a new **root** span (new trace).
+- `'newTraceWithLink'` – Always create a new **root** span and link it to the current active span (if any).
+
+> **Recommended:** Use `startMode` instead of the legacy `createNewSpan` flag. The flag is still supported for now, but will be removed in a future release.
+
+#### Example: Using Decorators
+
+```ts
 import { Traces } from '@brokerize/telemetry';
 
 class ExampleService {
-    @Traces.trace({
-        spanName: 'fetch-data',
-        attributes: { endpoint: '/api/data' }
-    })
-    async fetchData() {
-        // Implementation
-        return { status: 'success' };
-    }
+  @Traces.trace({
+    spanName: 'fetch-data',
+    attributes: { endpoint: '/api/data' },
+    startMode: 'createChild', // recommended
+  })
+  async fetchData() {
+    // Implementation
+    return { status: 'success' };
+  }
 }
 ```
 
-#### Example: Manual Tracing
+#### Example: Manual Tracing (recommended API)
 
-```typescript
+```ts
 import { Traces, SpanStatusCode } from '@brokerize/telemetry';
 
 async function processRequest() {
-    const { span, createdSpan } = Traces.getCurrentSpanOrCreateNew('process-request', {
-        attributes: { operation: 'process' }
-    });
+  // New API: getSpan with StartMode
+  const { span, createdSpan } = Traces.getSpan(
+    'process-request',
+    { attributes: { operation: 'process' } },
+    'createChild', // startMode
+    'app'          // moduleName (optional)
+  );
 
-    try {
-        // Implementation
-        Traces.setStatus({ code: SpanStatusCode.OK });
-    } catch (error) {
-        Traces.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-        throw error;
-    } finally {
-        if (createdSpan) span.end();
-    }
+  try {
+    // Implementation
+    Traces.setStatus({ code: SpanStatusCode.OK });
+  } catch (error: any) {
+    Traces.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+    throw error;
+  } finally {
+    if (createdSpan) span.end();
+  }
 }
 ```
 
-For detailed usage, see [Tracing](./docs/telemetry/tracing.md).
+> **Legacy helper** `getCurrentSpanOrCreateNew(spanName, options, createNewSpan, moduleName)` is still supported, but prefer `getSpan(spanName, options, startMode, moduleName)` going forward. Likewise, prefer `startMode` over `createNewSpan`.
 
-## Documentation
+## Changes in v2.x
 
-- **Metrics**: Learn how to define and use metrics in [Metrics.md](./docs/telemetry/metrics.md).
-- **Tracing**: Understand tracing and span management in [Tracing.md](./docs/telemetry/tracing.md).
+### Initialization changes (exporters & processors)
+
+- **New exporter input** via `exporter: { kind: 'otlp' | 'console' | 'noop', ... }` or a concrete `SpanExporter` instance.
+- **Precedence:**  
+  1) If `spanProcessors` is provided ⇒ used **as-is** (no implicit defaults).  
+  2) Else if `exporter` is provided ⇒ default **`BatchSpanProcessor(exporter)`** is attached (except for `noop`).  
+  3) Else ⇒ no exporter/processors (no-op exporting).
+- **Legacy flags** `url`, `localDebugging`, `concurrencyLimit` are supported but **deprecated**; prefer `exporter`.
+
+### `withTracing` Behavior (Sync vs. Async)
+
+> **New (opt-in, non-breaking):**  
+> `withTracing` behaves **naturally**: **synchronous** functions remain synchronous (no artificial Promise), **asynchronous** functions continue to return a Promise.  
+> For backward compatibility, a **legacy mode** forces **all** wrapped calls to return a Promise.
+
+#### Modes
+
+| Mode | Description | How to enable |
+| --- | --- | --- |
+| `natural-sync-async` (default) | Sync functions stay sync; async functions return a Promise. | `initInstrumentation({ tracingMode: 'natural-sync-async' })` or `TRACES_MODE=natural-sync-async` |
+| `legacy-always-promise` (deprecated) | **All** functions return a Promise, including sync functions. | `initInstrumentation({ tracingMode: 'legacy-always-promise' })` or `TRACES_MODE=legacy-always-promise` |
+
+When legacy mode is active, a one-time **deprecation warning** is logged. Please migrate to `natural-sync-async`.
+
+### Span Limits (Feature Flag)
+
+Span limits help prevent unbounded memory usage by constraining attribute sizes/counts, event counts, and link counts.
+
+- **Disabled by default** (to avoid surprise behavior changes).  
+- You can enable limits via:
+  - **Environment:** `TRACES_ENABLE_LIMITS=1`
+  - **Code:** pass `spanLimits` in `initInstrumentation(...)` (this also enables limits).
+
+When enabled without providing your own values, the following **defaults** are applied:
+
+```ts
+{
+  attributeValueLengthLimit: 12000,
+  attributeCountLimit: 128,
+  eventCountLimit: 128,
+  linkCountLimit: 128,
+  attributePerEventCountLimit: 16,
+  attributePerLinkCountLimit: 16
+}
+```
+
+> A one-time warning is logged when limits are **disabled** to encourage adoption. Future versions may enable limits by default.
+
+#### Examples
+
+**Enable via environment:**
+
+```bash
+export TRACES_ENABLE_LIMITS=1
+```
+
+**Enable and customize via code:**
+
+```ts
+initInstrumentation({
+  serviceName: 'my-service',
+  exporter: { kind: 'otlp', url: 'http://your-otel-collector:4318/v1/traces' },
+  spanLimits: {
+    attributeValueLengthLimit: 8000,
+    attributeCountLimit: 64,
+    eventCountLimit: 256,
+    linkCountLimit: 32,
+  },
+});
+```
+
+### Migration Guide
+
+Most users do not need changes. Consider the following updates:
+
+#### 1) Replace `createNewSpan` with `startMode` (recommended)
+
+**Before (legacy):**
+```ts
+@Traces.trace({ spanName: 'op', createNewSpan: true })
+```
+
+**After (recommended):**
+```ts
+@Traces.trace({ spanName: 'op', startMode: 'createChild' })
+```
+
+#### 2) Replace `getCurrentSpanOrCreateNew` with `getSpan`
+
+**Before (legacy helper):**
+```ts
+const { span, createdSpan } = Traces.getCurrentSpanOrCreateNew('op', { attributes: {...} }, true);
+```
+
+**After (recommended):**
+```ts
+const { span, createdSpan } = Traces.getSpan('op', { attributes: {...} }, 'createChild');
+```
+
+#### 3) Check for sync call sites using `.then(...)`
+
+If a wrapped synchronous function was treated as Promise:
+- temporarily enable `legacy-always-promise`, or
+- refactor call sites to use direct returns.
+
+#### 4) Adopt span limits
+
+- Enable via `TRACES_ENABLE_LIMITS=1` or pass `spanLimits` in code.
+- Be aware future versions may enable limits by default.
+
+#### Checklist
+
+1. Choose a global mode (`tracingMode` or `TRACES_MODE`).  
+2. Replace `createNewSpan` → `startMode` where possible.  
+3. Replace `getCurrentSpanOrCreateNew` → `getSpan`.  
+4. Search for `.then(` on call sites of sync functions and migrate as needed.  
+5. Decide whether to enable `spanLimits` now (env or code).  
+6. Watch for one-time deprecation and limits warnings.
+
+### Deprecations
+
+- `createNewSpan` is **deprecated**. Use `startMode: 'createChild'` instead.
+- `getCurrentSpanOrCreateNew` is **deprecated**. Use `getSpan(spanName, options, startMode, moduleName)` instead.
+- Global `legacy-always-promise` mode is **deprecated** and intended for migration only.
+- Span limits are currently opt-in; future versions may enable them by default.
+
+## Examples
+
+### Job Handling with Attributes
+
+```ts
+await Traces.withTracing(
+  jobQueueService.handleJob.bind(jobQueueService),
+  {
+    spanName: 'jobQueueService.handleJob',
+    attributes: {
+      jobId,
+      msg_action: msg.action,
+      queueTimes_delaySeconds: msg.queueTimes?.delaySeconds,
+      queueTimes_queuedAt: msg.queueTimes?.queuedAt,
+    },
+    startMode: 'createChild',
+  }
+)(job, timeout);
+```
+
+### Decorator with Dynamic Attributes and Conditional Tracing
+
+```ts
+class OrderService {
+  @Traces.trace({
+    spanName: 'processOrder',
+    attributes: { service: 'order' },
+    dynamicAttributes: (args) => ({ orderId: args[0] }),
+    startMode: 'createChild',
+    traceOnlyIf: (args, self, currentSpan) => process.env.ENABLE_TRACING === '1',
+  })
+  async processOrder(orderId: string) {
+    // ...
+  }
+}
+```
+
+## Docs
+
+- **Metrics**: Learn how to define and use metrics in [docs/telemetry/metrics.md](./docs/telemetry/metrics.md).
+- **Tracing**: For detailed usage, see [docs/telemetry/tracing.md](./docs/telemetry/tracing.md).

--- a/docs/telemetry/tracing.md
+++ b/docs/telemetry/tracing.md
@@ -1,253 +1,312 @@
 # Tracing
 
-This documentation describes how tracing is used within the project to track application workflows and analyze performance and errors.
+This document describes how tracing is used within the project to track application workflows and analyze performance and errors.
 
 ## Overview
 
-Tracing enables the tracking of requests and processes in a system by creating so-called **spans**. A span represents a single operation or work step within a process, such as an HTTP request, a database query, or a function. Spans are hierarchically organized to represent relationships between different operations and include metadata such as timestamps, attributes, and error information. Tracing is based on the OpenTelemetry library, which provides a standardized way to monitor distributed systems.
+Tracing tracks requests and internal processes by creating **spans**. A span represents a single operation (e.g., an HTTP request, a DB query, or a function). Spans form a hierarchy to express causal relations and include timestamps, attributes, and error/status information. The implementation is based on **OpenTelemetry**.
 
-### Main Goals of Tracing
+### Goals of Tracing
 
-- **Traceability**: Tracking the flow of requests through various components of a system.
-- **Performance Analysis**: Identifying bottlenecks and latency issues in applications.
-- **Error Diagnosis**: Capturing and analyzing errors to identify their causes.
-- **Context Tracking**: Linking operations across multiple services using trace IDs.
+- **Traceability**: Follow requests across system boundaries.
+- **Performance Analysis**: Identify bottlenecks and latency.
+- **Error Diagnosis**: Capture and analyze failures.
+- **Context Propagation**: Connect operations using trace/span IDs.
 
 ---
 
 ## Technical Implementation
 
-Tracing is implemented using the `Traces` class, which provides functions for creating, managing, and annotating spans. The class uses the OpenTelemetry API to create spans, add attributes, set statuses, and log errors or events.
+Tracing is implemented via the `Traces` class, which provides helpers for creating and managing spans, setting attributes and status, and recording exceptions and events. It uses the OpenTelemetry API under the hood.
 
 ---
 
 ## Using Tracing
 
-Tracing can be implemented either **manually** by directly using the `Traces` class or **automatically** by using the `@Trace` annotation.
+You can instrument code **automatically** with the `@Traces.trace` decorator or **manually** with `Traces` helpers.
 
-### Usage via Annotations
+### Usage via Decorators
 
-The `@Trace` annotation provides a simple way to automatically instrument methods with tracing. It creates or uses a span for the annotated method and automatically adds attributes, status, and error information. The annotation is particularly useful for integrating tracing into existing code without manual span management.
+The `@Traces.trace` decorator instruments a method: it creates (or reuses) a span, attaches attributes, manages status/error handling, and ends the span automatically.
 
-#### Schema of an Annotation
+> **Decorator compatibility:** Supports both **TC39** decorators (`(value, ctx)` for `method/getter/setter/field/auto-accessor`) **and** legacy **TypeScript** decorators (`(target, key, descriptor)`).
 
-```typescript
+```ts
 @Traces.trace(options)
 ```
 
-The `options` include the following attributes:
+**Options**:
 
-- `spanName` (_optional_): The name of the span. By default, the method name is used.
-- `attributes` (_optional_): Static key-value pairs added to the span as metadata (e.g., `{ endpoint: "/api/users" }`).
-- `dynamicAttributes` (_optional_): A function that returns dynamic attributes based on the method parameters.
-- `moduleName` (_optional_): The name of the module for the tracer. By default, the filename of the calling module is used.
-- `createNewSpan` (_optional_): If `true`, a new span is always created instead of using an existing one. The default is `false`.
+- `spanName` (_optional_): Span name. Defaults to the method name.
+- `attributes` (_optional_): Static key‑value pairs added as span attributes.
+- `dynamicAttributes` (_optional_): `(args) => Record<string, any>` computed per invocation; keys overwrite `attributes` on conflict.
+- `moduleName` (_optional_): Logical tracer name; defaults to the caller file.
+- `traceOnlyIf` (_optional_): `boolean | (args, thisContext, currentSpan?) => boolean` to conditionally enable tracing.
+- `startMode` (_optional_): **Parenting strategy** for the span (**recommended**; replaces legacy `createNewSpan`):
+  - `"reuse"` (default): Reuse the current active span if present; otherwise create a new one.
+  - `"createChild"`: Always create a new span (child if a parent is active; otherwise root).
+  - `"newTrace"`: Always create a new **root** span (new trace).
+  - `"newTraceWithLink"`: Create a new **root** span and link it to the current active span (if any).
+- `createNewSpan` (**deprecated**): Legacy flag equivalent to `startMode: "createChild"`.
 
-#### Example of an Annotation
+#### Example
 
-```typescript
+```ts
 import { Traces } from '@brokerize/telemetry';
 
 class ExampleService {
-    @Traces.trace({
-        spanName: 'fetch-users',
-        attributes: { endpoint: '/api/users' },
-        dynamicAttributes: (args) => ({
-            userId: args[0],
-            method: args[1]
-        })
-    })
-    async fetchUsers(userId: string, method: string) {
-        // Implementation
-        return { id: userId, status: 'success' };
-    }
+  @Traces.trace({
+    spanName: 'fetch-users',
+    attributes: { endpoint: '/api/users' },
+    dynamicAttributes: (args) => ({ userId: args[0], method: args[1] }),
+    traceOnlyIf: (args) => args[1] === 'GET',
+    startMode: 'reuse',
+  })
+  async fetchUsers(userId: string, method: string) {
+    // Implementation
+    return { id: userId, status: 'success' };
+  }
 }
 ```
 
-In this example:
+- A span named `fetch-users` is created (or reused).
+- Static and dynamic attributes are attached.
+- Tracing only happens when `method === "GET"`.
+- Status is set to `SpanStatusCode.OK` or `SpanStatusCode.ERROR` based on the outcome.
+- The span ends automatically.
 
-- A span named `fetch-users` is created.
-- Static attributes `{ endpoint: "/api/users" }` are added.
-- Dynamic attributes like `{ userId: "123", method: "GET" }` are added based on the method parameters.
-- The span is automatically ended when the method completes, and the status is set to `SpanStatusCode.OK` or `SpanStatusCode.ERROR` depending on the outcome.
+**Notes**
 
-#### Notes
-
-- **Asynchronous Methods**: The annotation supports both synchronous and asynchronous methods (Promises). Errors in asynchronous methods are automatically captured and logged as `SpanStatusCode.ERROR`.
-- **Span Hierarchy**: If a span is created in a context with an existing span, it is created as a child span of the current span unless `createNewSpan` is `true`.
-- **Limitation**: Annotations are only supported in classes, as TypeScript currently does not allow function decorators outside of classes.
+- Works with both sync and async methods. Errors are recorded and status is set accordingly.
+- Parent/child behavior is driven by `startMode` and the **active context**.
 
 ---
 
 ### Manual Usage
 
-For scenarios requiring more control over tracing, the `Traces` class can be used directly. This allows manual creation, management, and termination of spans, as well as adding attributes, status, and events.
+For granular control, use the `Traces` helpers directly.
 
-#### Key Methods of the `Traces` Class
+#### Key Methods (Recommended)
 
-| Method                                                                   | Description                                                                        |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `getCurrentSpanOrCreateNew(spanName, options, createNewSpan, moduleName)` | Returns the current span or creates a new one.                                      |
-| `getCurrentSpan()`                                                        | Returns the current active span, if available.                                      |
-| `setAttribute(key, value)`                                                | Adds a single attribute to the current span.                                        |
-| `setAttributes(attributes)`                                               | Adds multiple attributes to the current span.                                       |
-| `setStatus(status)`                                                       | Sets the status of the span (e.g., `SpanStatusCode.OK` or `SpanStatusCode.ERROR`). |
-| `recordException(error)`                                                  | Logs an exception in the current span.                                             |
-| `addEvent(name, attributes)`                                              | Adds an event with optional attributes to the current span.                         |
-| `withTracing(fn, options)`                                                | Wraps a function in a span and handles status, errors, and termination.             |
+| Method                                                                                      | Description                                                                                     |
+|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `getSpan(spanName, options, startMode?, moduleName?)`                                       | Start or reuse a span according to `startMode`. Returns `{ span, createdSpan }`.               |
+| `getCurrentSpan()`                                                                          | Returns the current active span, if any.                                                        |
+| `setAttribute(key, value)` / `setAttributes(obj)`                                           | Add attributes to the current span.                                                             |
+| `setStatus(status)`                                                                          | Set status (`SpanStatusCode.OK` / `SpanStatusCode.ERROR`, etc.).                                |
+| `recordException(error)`                                                                     | Record an exception on the current span.                                                        |
+| `addEvent(name, attributes?)`                                                                | Add a named event with optional attributes.                                                     |
+| `withTracing(fn, options)`                                                                   | Wrap a function; manages context, status, error handling, and span end.                         |
 
-#### Example of Manual Usage
+> **Deprecated helper:** `getCurrentSpanOrCreateNew(spanName, options?, createNewSpan?, moduleName?)` is still supported for now, but **use `getSpan(..., startMode, ...)`** going forward.
 
-```typescript
+#### Example with `getSpan`
+
+```ts
 import { Traces, SpanStatusCode } from '@brokerize/telemetry';
 
 async function processRequest(userId: string) {
-    const { span, createdSpan } = Traces.getCurrentSpanOrCreateNew('process-request', {
-        attributes: { userId }
-    });
+  const { span, createdSpan } = Traces.getSpan(
+    'process-request',
+    { attributes: { userId } },
+    'createChild', // startMode
+    'app'          // moduleName (optional)
+  );
 
-    try {
-        Traces.setAttribute('endpoint', '/api/process');
-        // Implementation
-        Traces.setStatus({ code: SpanStatusCode.OK });
-        return { status: 'success' };
-    } catch (error) {
-        Traces.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-        Traces.recordException(error);
-        throw error;
-    } finally {
-        if (createdSpan) {
-            span.end();
-        }
-    }
+  try {
+    Traces.setAttribute('endpoint', '/api/process');
+    // Implementation
+    Traces.setStatus({ code: SpanStatusCode.OK });
+    return { status: 'success' };
+  } catch (error: any) {
+    Traces.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+    Traces.recordException(error);
+    throw error;
+  } finally {
+    if (createdSpan) span.end();
+  }
 }
 ```
-
-In this example:
-
-- A new span named `process-request` is created.
-- Attributes like `userId` and `endpoint` are added.
-- The status is set based on the success or failure of the operation.
-- The span is manually ended if it was newly created.
 
 #### Example with `withTracing`
 
-```typescript
+```ts
 import { Traces } from '@brokerize/telemetry';
 
 const processData = Traces.withTracing(
-    async (data: string) => {
-        // Implementation
-        return { result: data.toUpperCase() };
-    },
-    {
-        spanName: 'process-data',
-        attributes: { operation: 'uppercase' },
-        dynamicAttributes: (args) => ({ inputLength: args[0].length })
-    }
+  async (data: string) => {
+    // Implementation
+    return { result: data.toUpperCase() };
+  },
+  {
+    spanName: 'process-data',
+    attributes: { operation: 'uppercase' },
+    dynamicAttributes: (args) => ({ inputLength: args[0].length }),
+    startMode: 'createChild',
+  }
 );
 
 async function main() {
-    const result = await processData('hello');
-    console.log(result); // { result: 'HELLO' }
+  const result = await processData('hello');
+  console.log(result); // { result: 'HELLO' }
 }
 ```
 
-In this example:
+**`withTracing` behavior (sync vs. async)**
 
-- The `processData` function is wrapped with a span.
-- The span receives static (`operation`) and dynamic (`inputLength`) attributes.
-- Errors and status are automatically handled, and the span is ended upon completion.
+- **Natural behavior (default)**: Synchronous functions remain synchronous; asynchronous functions return a Promise.
+- **Legacy behavior (opt‑in)**: Force all wrapped calls to return a Promise (see below).
 
----
-
-## Best Practices for Tracing
-
-1. **Meaningful Span Names**:
-
-    - Use clear, descriptive names like `fetch-users` or `process-request` instead of generic names like `operation`.
-    - Example: `db_query_select_users` instead of `query`.
-
-2. **Relevant Attributes**:
-
-    - Add attributes that describe the operation's context, such as `endpoint`, `method`, `userId`, or `region`.
-    - Avoid unnecessary or highly variable dynamically generated attributes (e.g., timestamps or unique IDs) to reduce cardinality.
-
-3. **Hierarchical Structure**:
-
-    - Leverage the hierarchical nature of spans to represent relationships between operations. Create child spans for sub-operations, e.g., a database query within an HTTP request.
-    - Set `createNewSpan: false` (default) to use existing spans unless a new context is required.
-
-4. **Error Handling**:
-
-    - Log errors with `recordException` to capture detailed information like stack traces.
-    - Set the span status to `SpanStatusCode.ERROR` for errors to mark the cause.
-
-5. **Performance Optimization**:
-
-    - Avoid creating unnecessary spans for trivial operations to minimize overhead.
-    - Use sampling rules (e.g., `otel.collector.sampling.keep`) to control the amount of collected data.
-
-6. **Consistency**:
-    - Use consistent naming conventions for spans and attributes, e.g., `snake_case` for span names and attributes.
-    - Example: `http_request_duration` instead of `HTTPRequestDuration`.
+You can control this globally via `tracingMode` / `TRACES_MODE`.
 
 ---
 
-## Common Mistakes and How to Avoid Them
+## Initialization
 
-| Mistake                              | Solution                                                                                 |
-| ------------------------------------- | -------------------------------------------------------------------------------------- |
-| **Too Many Spans**                   | Create spans only for relevant operations to avoid overhead.                             |
-| **High Cardinality from Attributes** | Avoid attributes with dynamic values like `user_id` or timestamps.                      |
-| **Missing Span Termination**         | Ensure spans are ended in `finally` blocks or through annotations.                      |
-| **Unclear Span Names**               | Use descriptive names that reflect the operation's purpose.                             |
-| **Missing Error Logging**            | Use `recordException` and `setStatus` for all error cases.                              |
+Use `initInstrumentation` to set up OpenTelemetry, exporters/processors, and behavior flags.
 
----
-
-## Integration with OpenTelemetry
-
-The `Traces` class is based on the OpenTelemetry API and is compatible with OpenTelemetry-compliant backends such as Jaeger, Zipkin, or Prometheus. To export tracing data, an OpenTelemetry exporter must be configured. For more information on configuration, refer to the [OpenTelemetry documentation](https://opentelemetry.io/docs/).
-
-This package provides the `initInstrumentation` method to automatically initialize and configure the OpenTelemetry exporter.
-
-### Initializing Instrumentation
-
-```typescript
-/*instrumentation.ts*/
+```ts
+/* instrumentation.ts */
 import { initInstrumentation } from '@brokerize/telemetry';
 import { AmqplibInstrumentation } from '@opentelemetry/instrumentation-amqplib';
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 
 initInstrumentation({
-    serviceName: 'my-service',
-    url: 'http://your-otel-collector:4318/v1/traces',
-    localDebugging: false,
-    concurrencyLimit: 10,
-    instrumentations: [
-        new HttpInstrumentation(),
-        new ExpressInstrumentation(),
-        new AmqplibInstrumentation({
-            useLinksForConsume: true
-        })
-    ]
+  serviceName: 'my-service',
+  instrumentations: [
+    new HttpInstrumentation(),
+    new ExpressInstrumentation(),
+    new AmqplibInstrumentation({ useLinksForConsume: true }),
+  ],
+  // Select global wrapper behavior:
+  tracingMode: 'natural-sync-async', // or 'legacy-always-promise' (deprecated)
+  // Optionally set explicit span limits (also enables limits if not enabled via env):
+  // spanLimits: { attributeValueLengthLimit: 12000, attributeCountLimit: 128, ... },
+
+  // ── Exporter/Processor configuration ────────────────────────────────────────
+  // EITHER: a simple exporter descriptor (library attaches a BatchSpanProcessor automatically)
+  exporter: { kind: 'otlp', url: 'http://your-otel-collector:4318/v1/traces' },
+  // exporter: { kind: 'console' } // for local debugging
+  // exporter: { kind: 'noop' }    // no-op exporting
+
+  // OR: full control via explicit processors (library will NOT add processors for you)
+  // spanProcessors: [
+  //   new BatchSpanProcessor(new OTLPTraceExporter({ url: 'http://your-otel-collector:4318/v1/traces' })),
+  // ],
 });
 ```
 
-The `initInstrumentation` function initializes the OpenTelemetry instrumentation and configures the exporter for tracing data. The parameters are:
-
-- `serviceName`: The name of the service displayed in tracing.
-- `url`: The URL of the OpenTelemetry Collector to which tracing data is sent.
-- `localDebugging`: Optional, if `true`, tracing data is stored locally and not sent to the collector. Useful for debugging purposes.
-- `concurrencyLimit`: Optional, the maximum number of concurrent spans that can be processed. Defaults to 10.
-- `instrumentations`: A list of OpenTelemetry instrumentations to be enabled. Various instrumentations such as `HttpInstrumentation`, `ExpressInstrumentation`, or `AmqplibInstrumentation` can be added here.
-
-It is critical to call the `initInstrumentation` function at the start of the application to ensure that all spans are correctly captured and exported.
-
-This can be done, for example, in a separate file like `instrumentation.ts`, which can then be included as follows:
+Run with Node’s `--import` if you prefer a separate bootstrap file:
 
 ```bash
 node --import /usr/src/api/dist/src/instrumentation.js /usr/src/api/dist/src/index.js
 ```
+
+### Exporter & Processor Precedence
+
+1. **You provide `spanProcessors`** → used **as-is** (no implicit defaults added).
+2. **Else if you provide `exporter`** (or legacy `url`/`localDebugging`) → a default **`BatchSpanProcessor(exporter)`** is attached (except for `noop`).
+3. **Else** → tracing runs with **no exporter** (no-op).
+
+> **Deprecated legacy flags:** `url`, `localDebugging`, `concurrencyLimit`. Prefer `exporter: { kind: 'otlp' | 'console' | 'noop' }` or pass a concrete `SpanExporter` instance.
+
+### Feature Flags & Environment Variables
+
+- `TRACES_MODE`:
+  - `natural-sync-async` (**default**): Sync stays sync; async returns Promise.
+  - `legacy-always-promise` (**deprecated**): All wrapped calls return Promises.
+- `TRACES_LEGACY_ASYNC_WRAPPER=1`: Shortcut to enable legacy behavior.
+- `TRACES_ENABLE_LIMITS=1`: Enable **span limits** (see below).
+
+A one‑time warning is logged when:
+- Legacy mode is active.
+- Span limits are **disabled** (to encourage adoption).
+
+---
+
+## Span Limits (Opt‑in)
+
+Span limits prevent unbounded memory usage by constraining attribute sizes/counts, events, and links.
+
+- **Disabled by default** to avoid unexpected behavior changes.
+- Enable via **env** `TRACES_ENABLE_LIMITS=1` or by passing **`spanLimits`** to `initInstrumentation` (this also enables limits).
+
+**Defaults applied when enabled** (if you don’t override them):
+
+```ts
+{
+  attributeValueLengthLimit: 12000,
+  attributeCountLimit: 128,
+  eventCountLimit: 128,
+  linkCountLimit: 128,
+  attributePerEventCountLimit: 16,
+  attributePerLinkCountLimit: 16
+}
+```
+
+Example:
+
+```ts
+initInstrumentation({
+  serviceName: 'my-service',
+  exporter: { kind: 'otlp', url: 'http://your-otel-collector:4318/v1/traces' },
+  spanLimits: {
+    attributeValueLengthLimit: 8000,
+    attributeCountLimit: 64,
+    eventCountLimit: 256,
+    linkCountLimit: 32,
+  },
+});
+```
+
+---
+
+## Best Practices
+
+1. **Meaningful Span Names**  
+   Use clear names like `fetch-users` or `process-request` rather than `operation`.
+
+2. **Relevant, Low‑Cardinality Attributes**  
+   Add contextual keys (`endpoint`, `method`, `region`, etc.) and avoid high‑cardinality values when possible.
+
+3. **Hierarchy Matters**  
+   Reflect sub‑operations with child spans; control parenting via `startMode` (e.g., `createChild`).
+
+4. **Error Handling**  
+   Use `recordException` and `setStatus` for failures; always end spans (the decorator does it for you).
+
+5. **Sampling & Volume Control**  
+   Use your collector/sampler to manage data volume; keep attribute sets bounded.
+
+6. **Consistency**  
+   Apply consistent naming conventions for spans and attributes (e.g., `snake_case`).
+
+---
+
+## Common Pitfalls
+
+| Pitfall                               | Solution                                                                                  |
+|---------------------------------------|-------------------------------------------------------------------------------------------|
+| Too many spans                        | Only create spans where they add value.                                                   |
+| High attribute cardinality            | Prefer bounded value sets; avoid unique IDs and timestamps unless necessary.              |
+| Missing span termination              | End spans in `finally` blocks or use the decorator.                                       |
+| Ambiguous span names                  | Use descriptive names reflecting the operation’s purpose.                                 |
+| Missing error logging                 | Use `recordException` + `setStatus` on failures.                                          |
+| Relying on legacy wrapper semantics   | Prefer `natural-sync-async`; use legacy mode only for temporary migration.                |
+
+---
+
+## Compatibility & Deprecations
+
+- **Use `startMode`** instead of `createNewSpan` (deprecated and will be removed in a future version).
+- **Use `getSpan(...)`** instead of `getCurrentSpanOrCreateNew(...)` (deprecated and will be removed in a future version).
+- **Legacy wrapper mode** (`legacy-always-promise`) is deprecated. Prefer the default `natural-sync-async` mode.
+
+---
+
+## Backends & Exporters
+
+`@brokerize/telemetry` works with OpenTelemetry‑compatible backends such as Jaeger or Zipkin. Configure an exporter (e.g., OTLP/HTTP) and point it at your collector.
+
+For more details, see the OpenTelemetry docs: https://opentelemetry.io/docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brokerize/telemetry",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brokerize/telemetry",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
@@ -18,16 +18,105 @@
         "@eslint/js": "9.22.0",
         "@swc/core": "1.12.7",
         "@types/express": "^4.17.21",
+        "@types/supertest": "6.0.3",
+        "@vitest/coverage-v8": "3.2.4",
         "eslint": "9.22.0",
         "eslint-plugin-simple-import-sort": "12.1.1",
+        "supertest": "7.1.4",
         "ts-node": "10.9.2",
         "tsx": "4.20.3",
         "typescript": "5.8.3",
         "typescript-eslint": "8.35.0",
-        "typescript-strict-plugin": "2.4.4"
+        "typescript-strict-plugin": "2.4.4",
+        "vitest": "3.2.4"
       },
       "peerDependencies": {
         "express": ">=4.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -716,6 +805,141 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -727,9 +951,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -752,6 +976,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1282,6 +1519,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1345,6 +1603,314 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@swc/core": {
       "version": "1.12.7",
@@ -1611,6 +2177,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1620,6 +2196,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1665,6 +2255,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1719,6 +2316,30 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1965,6 +2586,155 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2084,6 +2854,53 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz",
+      "integrity": "sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.30",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2231,12 +3048,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2250,7 +3076,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2272,6 +3097,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2287,6 +3129,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2363,6 +3215,29 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2410,6 +3285,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2449,6 +3331,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2467,6 +3359,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2490,6 +3392,17 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2505,7 +3418,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2514,6 +3426,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2553,7 +3472,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2563,19 +3481,40 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2806,6 +3745,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2848,6 +3797,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2963,6 +3922,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3071,6 +4037,71 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3129,7 +4160,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3154,7 +4184,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3192,6 +4221,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3203,6 +4253,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3223,7 +4299,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3252,7 +4327,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3271,6 +4361,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -3497,6 +4594,94 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3607,6 +4792,58 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -3619,7 +4856,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3665,7 +4901,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3701,7 +4936,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3711,7 +4945,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3742,6 +4975,16 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -3753,6 +4996,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3789,7 +5051,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3910,6 +5171,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3959,12 +5227,53 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3976,6 +5285,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -4065,7 +5403,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -4222,6 +5559,48 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -4389,7 +5768,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -4409,7 +5787,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -4426,7 +5803,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4445,7 +5821,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4460,12 +5835,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -4476,6 +5875,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4501,10 +5907,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4534,6 +5970,67 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {
@@ -4568,6 +6065,139 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4888,6 +6518,221 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -4914,6 +6759,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4928,6 +6790,25 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brokerize/telemetry",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A telemetry package for metrics and tracing powered by brokerize",
   "keywords": [
     "telemetry",
@@ -10,7 +10,9 @@
   ],
   "main": "dist/index.js",
   "files": [
-    "dist", "README.md", "docs"
+    "dist",
+    "README.md",
+    "docs"
   ],
   "exports": {
     ".": {
@@ -23,7 +25,12 @@
   "author": "brokerize",
   "type": "module",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "prepublishOnly": "npm run build && npm run typecheck && npm run test"
   },
   "lint-staged": {
     "*.{js,ts}": [
@@ -45,7 +52,7 @@
     "useTabs": false
   },
   "dependencies": {
-    "@opentelemetry/api" : "1.9.0",
+    "@opentelemetry/api": "1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
     "@opentelemetry/sdk-node": "0.202.0",
     "@opentelemetry/sdk-trace-base": "2.0.1",
@@ -54,14 +61,18 @@
   "devDependencies": {
     "@eslint/js": "9.22.0",
     "@swc/core": "1.12.7",
-    "eslint": "9.22.0",
     "@types/express": "^4.17.21",
+    "@types/supertest": "6.0.3",
+    "@vitest/coverage-v8": "3.2.4",
+    "eslint": "9.22.0",
     "eslint-plugin-simple-import-sort": "12.1.1",
+    "supertest": "7.1.4",
     "ts-node": "10.9.2",
     "tsx": "4.20.3",
     "typescript": "5.8.3",
     "typescript-eslint": "8.35.0",
-    "typescript-strict-plugin": "2.4.4"
+    "typescript-strict-plugin": "2.4.4",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "express": ">=4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Re-exportiere alles aus den gewünschten Verzeichnissen
 export * from './metrics/httpMetrics.ts';
 export { metrics, MetricType } from './metrics/metrics.ts';
 export * from './metrics/metricsDecorator.ts';
@@ -6,4 +5,3 @@ export * from './metrics/metricsDecorator.ts';
 export * from './tracing/tracingDecorator.ts';
 
 export * from './instrumentation.ts';
-// NICHT: util

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,79 +1,261 @@
-/*instrumentation.ts*/
-import { diag, DiagConsoleLogger, DiagLogLevel, trace } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { diag, DiagConsoleLogger, DiagLogLevel, trace, context, propagation } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { ExportResultCode } from '@opentelemetry/core';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import type { SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { SpanExporter, SpanLimits, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { BatchSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import {
+    setTracingMode,
+    TracingMode,
+    getEnableSpanLimits,
+    setEnableSpanLimits,
+    maybeWarnLegacy
+} from './tracing/tracing-config.ts';
 
-// For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
-let sdk: NodeSDK | undefined = undefined;
-let contextManager: AsyncHooksContextManager | undefined = undefined;
-let traceExporter: SpanExporter | undefined = undefined;
-let spanProcessors: SpanProcessor[] | undefined = undefined;
+let sdk: NodeSDK | undefined;
+let contextManager: AsyncLocalStorageContextManager | undefined;
+let createdTraceExporter: SpanExporter | undefined;
+let effectiveSpanProcessors: SpanProcessor[] | undefined;
 
-function buildExporterOptions(options?: { url?: string; localDebugging?: boolean; concurrencyLimit?: number }): {
-    traceExporter: SpanExporter;
-    spanProcessors: SpanProcessor[] | undefined;
-} {
-    if (!options?.localDebugging && !options?.url) {
-        /* no-op exporter for automated testing */
-        return {
-            traceExporter: {
-                export: (spans, resultCallback) => {
-                    resultCallback({
-                        code: ExportResultCode.SUCCESS
-                    });
-                },
-                shutdown: async () => {},
-                forceFlush: async () => {}
-            } satisfies SpanExporter,
-            spanProcessors: undefined
-        };
-    } else if (options?.localDebugging) {
-        diag.info('Using ConsoleSpanExporter');
-        return {
-            traceExporter: new ConsoleSpanExporter(),
-            spanProcessors: undefined
-        };
-    } else {
-        const collectorOptions = {
-            url: options.url,
-            concurrencyLimit: options.concurrencyLimit ?? 10
-        };
-        diag.info('Using OTLPTraceExporter');
-        diag.info('collectorOptions: ' + JSON.stringify(collectorOptions));
-        const traceExporter = new OTLPTraceExporter(collectorOptions);
-        return {
-            traceExporter,
-            spanProcessors: [
-                new BatchSpanProcessor(traceExporter, {
-                    // The maximum queue size. After the size is reached spans are dropped.
-                    maxQueueSize: 1000,
-                    // The interval between two consecutive exports
-                    scheduledDelayMillis: 5000
-                })
-            ]
-        };
-    }
+const NOOP_EXPORTER_FLAG = '__brokerize_noop_exporter__' as const;
+type NoopFlagged = { [NOOP_EXPORTER_FLAG]?: true };
+
+/**
+ * Declarative configuration for the span exporter used by `initInstrumentation`.
+ *
+ * - Pass a **concrete `SpanExporter`** instance for full control.
+ * - Or use a **descriptor** to let this library construct a sensible default exporter.
+ *
+ * @example
+ * // Full control (you build processors yourself):
+ * initInstrumentation({
+ *   serviceName: 'svc',
+ *   spanProcessors: [
+ *     new BatchSpanProcessor(new OTLPTraceExporter({ url: 'http://otel:4318/v1/traces' }))
+ *   ]
+ * });
+ *
+ * @example
+ * // Simple path (let the lib build a BatchSpanProcessor for you):
+ * initInstrumentation({
+ *   serviceName: 'svc',
+ *   exporter: { kind: 'otlp', url: 'http://otel:4318/v1/traces' }
+ * });
+ */
+export type ExporterInput =
+    | SpanExporter
+    | { kind: 'otlp'; url: string; concurrencyLimit?: number }
+    | { kind: 'console' }
+    | { kind: 'noop' }
+    | undefined;
+
+function makeNoopExporter(): SpanExporter & NoopFlagged {
+    const e: SpanExporter & NoopFlagged = {
+        export: (_spans, cb) => cb({ code: ExportResultCode.SUCCESS }),
+        shutdown: async () => {},
+        forceFlush: async () => {}
+    };
+    e[NOOP_EXPORTER_FLAG] = true;
+    return e;
 }
 
-export function initInstrumentation(options: {
-    serviceName: string;
+function resolveExporter(opts: {
+    exporter?: ExporterInput;
     url?: string;
     localDebugging?: boolean;
     concurrencyLimit?: number;
+}): SpanExporter | undefined {
+    if (opts.exporter) {
+        if (typeof (opts.exporter as any).export === 'function') {
+            return opts.exporter as SpanExporter;
+        }
+        const e = opts.exporter as Exclude<ExporterInput, SpanExporter>;
+        switch (e!.kind) {
+            case 'console':
+                diag.info('Using ConsoleSpanExporter (explicit)');
+                return new ConsoleSpanExporter();
+            case 'noop':
+                diag.info('Using Noop SpanExporter (explicit)');
+                return makeNoopExporter();
+            case 'otlp': {
+                const { url, concurrencyLimit = 10 } = e!;
+                diag.info('Using OTLPTraceExporter (explicit)');
+                diag.info('collectorOptions: ' + JSON.stringify({ url, concurrencyLimit }));
+                return new OTLPTraceExporter({ url, concurrencyLimit });
+            }
+        }
+    }
+
+    if (!opts.localDebugging && !opts.url) {
+        diag.info('No exporter configured (legacy) → Noop exporter');
+        return makeNoopExporter();
+    }
+    if (opts.localDebugging) {
+        diag.info('Using ConsoleSpanExporter (legacy localDebugging)');
+        return new ConsoleSpanExporter();
+    }
+    const url = opts.url!;
+    const concurrencyLimit = opts.concurrencyLimit ?? 10;
+    diag.info('Using OTLPTraceExporter (legacy)');
+    diag.info('collectorOptions: ' + JSON.stringify({ url, concurrencyLimit }));
+    return new OTLPTraceExporter({ url, concurrencyLimit });
+}
+
+function resolveSpanProcessors(
+    exporter: (SpanExporter & Partial<NoopFlagged>) | undefined,
+    provided: SpanProcessor[] | undefined
+): SpanProcessor[] | undefined {
+    if (Array.isArray(provided) && provided.length > 0) {
+        return provided;
+    }
+
+    if (!exporter) return undefined;
+
+    if ((exporter as NoopFlagged)[NOOP_EXPORTER_FLAG]) {
+        return undefined;
+    }
+
+    diag.info('Using default BatchSpanProcessor');
+    return [
+        new BatchSpanProcessor(exporter, {
+            maxQueueSize: 1000,
+            scheduledDelayMillis: 5000
+        })
+    ];
+}
+
+/**
+ * Options for {@link initInstrumentation}.
+ *
+ * @remarks
+ * **Precedence & behavior**
+ *
+ * 1. If you provide **`spanProcessors`**, those processors are used **as-is**.
+ *    The library does **not** auto-attach any exporter/processor.
+ * 2. If you do **not** provide `spanProcessors` but provide an **`exporter`** (or legacy `url`/`localDebugging`),
+ *    the library will create a **`BatchSpanProcessor`** for you (except for `noop`).
+ * 3. If neither `spanProcessors` nor exporter info is provided, tracing behaves as **No-Op** (spans not exported).
+ */
+export interface InitOptions {
+    /**
+     * Logical service name used in resource attributes and tracing.
+     */
+    serviceName: string;
+
+    /**
+     * Preferred way to configure the exporter (or provide a concrete `SpanExporter`).
+     * If omitted, legacy flags (`url`, `localDebugging`) are considered.
+     */
+    exporter?: ExporterInput;
+
+    /**
+     * Legacy: OTLP endpoint used to construct an `OTLPTraceExporter`.
+     * Ignored if `exporter` or `spanProcessors` is provided.
+     * @deprecated Use {@link InitOptions.exporter} with `{ kind: 'otlp', url }`
+     */
+    url?: string;
+
+    /**
+     * Legacy: when `true`, use a `ConsoleSpanExporter` for local debugging.
+     * Ignored if `exporter` or `spanProcessors` is provided.
+     * @deprecated Use {@link InitOptions.exporter} with `{ kind: 'console' }`
+     */
+    localDebugging?: boolean;
+
+    /**
+     * Legacy: concurrency limit for the legacy OTLP exporter.
+     * Only applies when using {@link InitOptions.url}.
+     * @deprecated Use {@link InitOptions.exporter} with `{ kind: 'otlp', concurrencyLimit }`
+     */
+    concurrencyLimit?: number;
+
+    /**
+     * Auto-instrumentations to enable (e.g., HttpInstrumentation).
+     */
     instrumentations?: any[];
-}) {
+
+    /**
+     * Span limits (enables limits when provided or when the env flag is set).
+     * If you pass this object, span limits are turned on automatically.
+     */
+    spanLimits?: Partial<SpanLimits>;
+
+    /**
+     * Global `withTracing` mode.
+     * - `'natural-sync-async'` (default): sync stays sync; async returns Promise.
+     * - `'legacy-always-promise'` (deprecated): forces Promise for all wrapped calls.
+     *
+     * @remarks
+     * The `'legacy-always-promise'` mode is intended for migration only and will log a one-time deprecation warning.
+     */
+    tracingMode?: TracingMode;
+
+    /**
+     * Provide custom span processor chain. If set, the library will **not** create any processor for you.
+     * Recommended when you need full control over batching/queuing or want to attach multiple processors.
+     *
+     * @example
+     * spanProcessors: [
+     *   new BatchSpanProcessor(new OTLPTraceExporter({ url: '...' })),
+     *   new AnotherCustomProcessor()
+     * ]
+     */
+    spanProcessors?: SpanProcessor[];
+}
+
+/**
+ * Initialize OpenTelemetry for this process (NodeSDK, context manager, exporter/processors, limits, instrumentations).
+ *
+ * @param options - {@link InitOptions} controlling exporter, processors, limits, mode, and instrumentations.
+ * @returns An object with the created `sdk`, the effective `traceExporter`, and the resolved `spanProcessors`.
+ *
+ * @remarks
+ * **Precedence**
+ * - If `spanProcessors` is provided, they are used **as-is**; no implicit exporter/processor is added.
+ * - Else, an exporter from `exporter` (preferred) or legacy `url`/`localDebugging` is resolved,
+ *   and a default `BatchSpanProcessor(exporter)` is attached (except for `noop`).
+ *
+ * **Legacy**
+ * - `url`, `localDebugging`, and `concurrencyLimit` are **deprecated**. Prefer `exporter` instead.
+ * - Tracing mode `'legacy-always-promise'` is deprecated and should be used only for migration.
+ *
+ * **Idempotency**
+ * - Intended to be called **once** per process at startup.
+ * - Repeated calls without shutdown may produce multiple SDKs/processors.
+ *
+ * **Examples**
+ * @example
+ * // Simple (SDK builds BatchSpanProcessor for OTLP)
+ * initInstrumentation({
+ *   serviceName: 'my-svc',
+ *   exporter: { kind: 'otlp', url: 'http://localhost:4318/v1/traces' }
+ * });
+ *
+ * @example
+ * // Full control (you provide processors)
+ * initInstrumentation({
+ *   serviceName: 'my-svc',
+ *   spanProcessors: [
+ *     new BatchSpanProcessor(new OTLPTraceExporter({ url: 'http://localhost:4318/v1/traces' }))
+ *   ]
+ * });
+ *
+ * @example
+ * // Console exporter for local debugging
+ * initInstrumentation({
+ *   serviceName: 'my-svc',
+ *   exporter: { kind: 'console' }
+ * });
+ */
+export function initInstrumentation(options: InitOptions) {
     diag.info('Initializing OpenTelemetry instrumentation');
     if (options.instrumentations && options.instrumentations.length > 0) {
         diag.info('Using instrumentations:');
         options.instrumentations.forEach((instrumentation) => {
-            if (instrumentation && instrumentation.constructor && instrumentation.constructor.name) {
+            if (instrumentation?.constructor?.name) {
                 diag.info(`- ${instrumentation.constructor.name}`);
             } else {
                 diag.warn('An instrumentation was provided without a valid constructor name.');
@@ -82,55 +264,97 @@ export function initInstrumentation(options: {
     } else {
         diag.info('No instrumentations specified, using none.');
     }
-    contextManager = new AsyncHooksContextManager().enable();
-    ({ traceExporter, spanProcessors } = buildExporterOptions({
+
+    contextManager = new AsyncLocalStorageContextManager().enable();
+
+    const exporter = resolveExporter({
+        exporter: options.exporter,
         url: options.url,
         localDebugging: options.localDebugging,
         concurrencyLimit: options.concurrencyLimit
-    }));
-    traceExporter = traceExporter;
-    spanProcessors = spanProcessors;
+    });
+
+    const processors = resolveSpanProcessors(exporter, options.spanProcessors);
+
+    createdTraceExporter = exporter;
+    effectiveSpanProcessors = processors;
+
+    let spanLimitOptions: SpanLimits | {} = {};
+    if (options.spanLimits || getEnableSpanLimits()) {
+        spanLimitOptions = {
+            attributeValueLengthLimit: 12000,
+            attributeCountLimit: 128,
+            eventCountLimit: 128,
+            linkCountLimit: 128,
+            attributePerEventCountLimit: 16,
+            attributePerLinkCountLimit: 16,
+            ...options.spanLimits
+        };
+        setEnableSpanLimits(true);
+        diag.info('Span limits enabled: ' + JSON.stringify(spanLimitOptions));
+    }
+
     sdk = new NodeSDK({
-        contextManager: contextManager,
+        contextManager,
         serviceName: options.serviceName,
-        traceExporter,
-        spanProcessors,
+        spanProcessors: processors,
+        ...(processors?.length ? {} : { traceExporter: exporter }),
+        spanLimits: spanLimitOptions,
         instrumentations: options.instrumentations || []
     });
 
+    if (options.tracingMode) setTracingMode(options.tracingMode);
+
     sdk.start();
+    maybeWarnLegacy(diag);
     diag.info('Tracing initialized');
+
     return {
         sdk,
-        traceExporter,
-        spanProcessors
+        traceExporter: createdTraceExporter,
+        spanProcessors: effectiveSpanProcessors
     };
 }
 
+/** Gracefully shuts down the OpenTelemetry SDK and its components.
+ * This includes flushing and shutting down the trace exporter,
+ * shutting down the SDK, and disabling context propagation.
+ */
 export async function shutDownInstrumentation() {
     try {
         diag.info('Shutting down OpenTelemetry instrumentation');
+
         if (!sdk) {
             diag.warn('No OpenTelemetry SDK instance found. Nothing to shut down.');
             return;
         }
-        if (!traceExporter) {
+
+        if (!createdTraceExporter) {
             diag.warn('No trace exporter found. Nothing to shut down.');
-            return;
-        }
-        if (typeof traceExporter.forceFlush === 'function') {
-            await traceExporter.forceFlush().catch((err) => {
-                diag.warn('OTLP forceFlush failed. Ignoring and continuing shutdown.', err);
+        } else {
+            if (typeof createdTraceExporter.forceFlush === 'function') {
+                await createdTraceExporter.forceFlush().catch((err) => {
+                    diag.warn('OTLP forceFlush failed. Ignoring and continuing shutdown.', err);
+                });
+            }
+            await createdTraceExporter.shutdown().catch((err) => {
+                diag.warn('OTLP shutdown failed. Ignoring and continuing shutdown.', err);
             });
         }
-
-        await traceExporter.shutdown().catch((err) => {
-            diag.warn('OTLP shutdown failed. Ignoring and continuing shutdown.', err);
-        });
 
         await sdk.shutdown().catch((err) => {
             diag.warn('OpenTelemetry SDK shutdown failed. Ignoring and continuing shutdown.', err);
         });
+
+        trace.disable();
+        contextManager?.disable?.();
+        propagation.disable();
+        context.disable();
+
+        createdTraceExporter = undefined;
+        effectiveSpanProcessors = undefined;
+        contextManager = undefined;
+        sdk = undefined;
 
         diag.info('Instrumentation shut down successfully.');
     } catch (error) {

--- a/src/tracing/tracing-config.ts
+++ b/src/tracing/tracing-config.ts
@@ -1,0 +1,39 @@
+export type TracingMode = 'legacy-always-promise' | 'natural-sync-async';
+
+let mode: TracingMode =
+    (process.env.TRACES_MODE as TracingMode) ||
+    (process.env.TRACES_LEGACY_ASYNC_WRAPPER === '1' ? 'legacy-always-promise' : 'natural-sync-async');
+let enableSpanLimits = process.env.TRACES_ENABLE_LIMITS === '1' || false;
+let warnOncePromise = false;
+let warnOnceLimits = false;
+export function setTracingMode(m: TracingMode) {
+    mode = m;
+}
+export function getTracingMode() {
+    return mode;
+}
+export function getEnableSpanLimits() {
+    return enableSpanLimits;
+}
+export function setEnableSpanLimits(enable: boolean) {
+    enableSpanLimits = enable;
+}
+
+export function maybeWarnLegacy(diag?: { warn: (...a: any[]) => void }) {
+    if (mode === 'legacy-always-promise' && diag && !warnOncePromise) {
+        warnOncePromise = true;
+        diag.warn(
+            '[Tracing] Legacy mode active: sync functions are wrapped into Promises. ' +
+                'This behavior is deprecated; switch to TRACES_MODE=natural-sync-async.' +
+                'This behavior will be removed in future versions and only natural-sync-async mode will be supported.'
+        );
+    }
+    if (!warnOnceLimits && !enableSpanLimits && diag) {
+        warnOnceLimits = true;
+        diag.warn(
+            '[Tracing] Span limits are disabled. This may lead to increased memory consumption. ' +
+                'To enable span limits, set TRACES_ENABLE_LIMITS=1. You can set the span limits ' +
+                'using the spanLimits option when initializing the SDK. Span limits are enabled by default in future versions.'
+        );
+    }
+}

--- a/src/tracing/tracingDecorator.ts
+++ b/src/tracing/tracingDecorator.ts
@@ -1,20 +1,144 @@
 // @ts-strict-ignore
-import type { Span, SpanContext, SpanOptions } from '@opentelemetry/api';
+import type { Context, Span, SpanContext, SpanOptions } from '@opentelemetry/api';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 
 import { getCallerFile } from '../util/util.ts';
 
+import { getTracingMode } from './tracing-config.ts';
+
+/**
+ * Strategy for obtaining a span in relation to the currently active context.
+ *
+ * - `reuse` – If there is an active span in `context.active()`, **reuse it**
+ *   (no new span is created). If `context.active()` is not set, a new span will be created.
+ *   Useful when you want to enrich an existing span with attributes/events/status without increasing span cardinality.
+ *
+ * - `createChild` – **Always create a new span**. If an active span
+ *   exists, the new span becomes its **child** (parent is taken from
+ *   `context.active()`). If no active span exists, the new span becomes a
+ *   **root** span. This is the idiomatic OpenTelemetry default for “make a new
+ *   span for this operation.”
+ *
+ * - `newTrace` – **Always create a new root span** (a brand-new trace). The
+ *   active context is ignored for parenting. Use this when you intentionally
+ *   want an operation to be tracked as an independent trace (e.g., a detached
+ *   background job).
+ * - `newTraceWithLink` – **Always create a new root span** (a brand-new trace),
+ *   but link it to the current active span, if any. This is useful for batch
+ *   processing jobs that are triggered by a request but run independently of
+ *   it. The new trace can be linked to the triggering request's span to allow
+ *   tracing systems to discover the relationship.
+ */
+type StartMode = 'reuse' | 'createChild' | 'newTrace' | 'newTraceWithLink';
+
+/**
+ * Options for the `@trace` decorator and the `withTracing()` wrapper.
+ *
+ * @property spanName
+ * Human-readable span name. Defaults to the function/method name.
+ *
+ * @property attributes
+ * Static attributes to set on every span created for this function.
+ *
+ * @property dynamicAttributes
+ * Callback that receives the invocation arguments and returns attributes to
+ * add to the span. Its return wins on key conflicts with `attributes`.
+ *
+ * @property moduleName
+ * Logical tracer name passed to `trace.getTracer(...)`. Defaults to the caller file.
+ *
+ * @property startMode
+ * Span parenting strategy. See {@link StartMode}. Defaults to `'reuse'`.
+ * - `'reuse'`        → reuse the active span if present; otherwise create a new one
+ * - `'createChild'`  → always create a new span (child if a parent is active; else root)
+ * - `'newTrace'`     → always create a new **root** span (new trace)
+ *
+ * @property traceOnlyIf
+ * Enables conditional tracing. If `false`, no tracing is performed.
+ * If a function is provided, it is evaluated at call time and may inspect
+ * the invocation arguments and the current active span to decide.
+ *
+ * @property createNewSpan
+ *
+ * @remarks
+ * - `dynamicAttributes` is evaluated per call; avoid heavy work inside it.
+ * @example Basic usage (always child if a parent exists)
+ * ```ts
+ * class OrderService {
+ *   @Traces.trace({
+ *     spanName: 'processOrder',
+ *     attributes: { service: 'order' },
+ *     startMode: 'createChild',
+ *     moduleName: 'order-service'
+ *   })
+ *   async processOrder(orderId: string) { ...  }
+ * }
+ * ```
+ *
+ * @example Conditional tracing by flag and arguments
+ * ```ts
+ * @Traces.trace({
+ *   startMode: 'reuse',
+ *   traceOnlyIf: (args) => process.env.ENABLE_TRACING === '1'
+ * })
+ * function computeTotal(cart: Cart) {  ... *}
+ * ```
+ */
 export interface TraceDecoratorOptions {
+    /** Human-readable span name. Defaults to the function/method name. */
     spanName?: string;
+
+    /** Static attributes to set on the span. */
     attributes?: Record<string, any>;
+
+    /**
+     * Derive per-invocation attributes from call arguments.
+     * Returned keys override duplicates from `attributes`.
+     */
     dynamicAttributes?: (args: any[]) => Record<string, any>;
+
+    /** Logical tracer name passed to `trace.getTracer(...)`. Defaults to caller file. */
     moduleName?: string;
+
+    /**
+     * Span parenting strategy. Defaults to `'reuse'`.
+     * - `'reuse'`       → reuse the active span if present; else create new
+     * - `'createChild'` → always new span (child if parent active; else root)
+     * - `'newTrace'`    → always new **root** span (new trace)
+     */
+    startMode?: StartMode;
+
+    /**
+     * Conditional tracing. If `false`, no tracing. If a function, it is called
+     * with the invocation arguments and may inspect them to decide.
+     */
+    traceOnlyIf?: boolean | ((args: any[], thisContext: any, currentSpan?: Span) => boolean);
+
+    /**
+     * @deprecated Use `startMode` instead.
+     * If `true`, treated as `startMode: 'createChild'`.
+     */
     createNewSpan?: boolean;
 }
 
 type FunctionToTrace = (...args: any[]) => any;
 
 export class Traces {
+    /**
+     * Returns the current active span, or creates and returns a new span if none is active.
+     *
+     * @param spanName - The name of the span to create if needed.
+     * @param options - Standard OpenTelemetry {@link SpanOptions}.
+     *   - Note: If a new span is created, `options.root` is ignored and the new span becomes a child
+     *     of the current active span, if any.
+     * @param createNewSpan - If `true`, always create a new span; if `false`, reuse the current active span if any.
+     *   - Note: If `createNewSpan` is `false` and there is no active span, a new span is created.
+     * @param moduleName - Logical tracer name (passed to `trace.getTracer`). Defaults to the caller file.
+     * @returns An object with `{ span, createdSpan }`, where:
+     * - `createdSpan` is `true` if a new span was created, `false` if the current active span was reused.
+     * - `span` is the current active span or the newly created span.
+     *@deprecated Use {@link Traces.getSpan} with `mode: 'reuse' | 'createChild'` instead.
+     */
     static getCurrentSpanOrCreateNew(
         spanName: string,
         options?: SpanOptions,
@@ -32,11 +156,88 @@ export class Traces {
 
         return { span, createdSpan };
     }
-
+    /** Returns the current active span, or `undefined` if none is active.
+     */
     static getCurrentSpan(): Span | undefined {
         return trace.getSpan(context.active());
     }
 
+    /**
+     * Returns a span according to the requested {@link StartMode}.
+     *
+     * @param spanName - The name of the span to start or reuse.
+     * @param options - Standard OpenTelemetry {@link SpanOptions}.
+     *   - Note: When `mode` is `"newTrace"`, the implementation will honor `options.root = true`
+     *     (or equivalent) to ensure the span is created as a root/span of a new trace.
+     * @param mode - Parenting strategy. See {@link StartMode}. Defaults to `"reuse"`.
+     * @param moduleName - Logical tracer name (passed to `trace.getTracer`). Defaults to the caller file.
+     * @returns An object with `{ span, createdSpan }`, where:
+     * - `createdSpan` is `false` only in `"reuse"` mode when an active span exists and is reused.
+     * - Otherwise a new span is created and `createdSpan` is `true`.
+     *
+     * @remarks
+     * - **Child-vs-root behavior:** OpenTelemetry determines parentage from the **active context**.
+     *   In `"createChildIfActive"`, a new span is started; if a parent span is active it becomes a child,
+     *   otherwise it becomes a root span. In `"newTrace"`, a new root span is started regardless of context.
+     * @example
+     * // Reuse the current span (no new span created)
+     * const { span, createdSpan } = Traces.getSpan('ignored-name', {}, 'reuse', 'orders-service');
+     * // createdSpan === false
+     *
+     * @example
+     * // Create a new span (child if a parent is active, else root)
+     * const { span } = Traces.getSpan('validate-order', { attributes: { orderId } }, 'createChildIfActive', 'orders-service');
+     * // ...do work...
+     * span.end();
+     *
+     * @example
+     * // Force a new root span (new trace), ignoring any active parent
+     * const { span } = Traces.getSpan('batch-reindex', { ... }, 'newTrace', 'maintenance');
+     * // ...do work...
+     * span.end();
+     */
+    static getSpan(
+        spanName: string,
+        options?: SpanOptions,
+        mode: StartMode = 'reuse',
+        moduleName = getCallerFile()
+    ): { span: Span; createdSpan: boolean } {
+        const tracer = trace.getTracer(moduleName);
+        const opts = this._setSamplingRule(options);
+
+        if (mode === 'reuse') {
+            const active = trace.getSpan(context.active());
+            if (active) return { span: active, createdSpan: false };
+        }
+
+        if (mode === 'newTrace') {
+            const span = tracer.startSpan(spanName, { ...opts, root: true });
+            return { span, createdSpan: true };
+        }
+
+        if (mode === 'newTraceWithLink') {
+            const active = trace.getSpan(context.active());
+            if (active) {
+                const span = tracer.startSpan(spanName, {
+                    ...opts,
+                    root: true,
+                    links: [{ context: active.spanContext() }]
+                });
+                return { span, createdSpan: true };
+            } else {
+                const span = tracer.startSpan(spanName, { ...opts, root: true });
+                return { span, createdSpan: true };
+            }
+        }
+
+        const span = tracer.startSpan(spanName, opts);
+        return { span, createdSpan: true };
+    }
+    /** Sets multiple attributes on the current active span.
+     * If no span is active, does nothing.
+     *
+     * @param attributes - Key-value pairs of attributes to set.
+     */
     static setAttributes(attributes: Record<string, any>) {
         const span = this.getCurrentSpan();
         if (span) {
@@ -45,7 +246,12 @@ export class Traces {
             }
         }
     }
-
+    /** Sets an attribute on the current active span.
+     * If no span is active, does nothing.
+     *
+     * @param key - Attribute key.
+     * @param value - Attribute value.
+     */
     static setAttribute(key: string, value: any) {
         const span = this.getCurrentSpan();
         if (span) {
@@ -53,20 +259,34 @@ export class Traces {
         }
     }
 
+    /** Sets the status on the current active span.
+     * If no span is active, does nothing.
+     *
+     * @param status - The status to set on the span.
+     */
     static setStatus(status: { code: SpanStatusCode; message?: string }) {
         const span = this.getCurrentSpan();
         if (span) {
             span.setStatus(status);
         }
     }
-
+    /** Records an exception on the current active span.
+     * If no span is active, does nothing.
+     *
+     * @param error - The exception to record.
+     */
     static recordException(error: Error) {
         const span = this.getCurrentSpan();
         if (span) {
             span.recordException(error);
         }
     }
-
+    /** Adds an event to the current active span.
+     * If no span is active, does nothing.
+     *
+     * @param name - The name of the event.
+     * @param attributes - Optional attributes to add to the event.
+     */
     static addEvent(name: string, attributes?: Record<string, any>) {
         const span = this.getCurrentSpan();
         if (span) {
@@ -74,122 +294,205 @@ export class Traces {
         }
     }
 
+    /** Logs the hierarchy of spans.
+     * @param span - The span to log.
+     */
     private static logSpanHierarchy(span: Span) {
         const spanContext: SpanContext = span.spanContext();
-        const parentSpan = this.getCurrentSpan(); // Den aktuellen aktiven Span als Eltern-Span betrachten, falls vorhanden
+        const parentSpan = this.getCurrentSpan();
 
         if (parentSpan) {
             const parentContext = parentSpan.spanContext();
         }
     }
-
-    static trace = (options: TraceDecoratorOptions = { createNewSpan: false }) => {
-        return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
-            const originalMethod = descriptor.value;
-            const moduleName = options.moduleName || target.constructor.name;
-
-            descriptor.value = function (...args: any[]) {
-                const spanName = options.spanName || propertyKey;
-                let dynamicLabels: Record<string, any> = {};
-
-                if (!options.attributes) {
-                    options.attributes = {};
+    /** Method decorator that traces the decorated method.
+     *
+     * @param options - Options for the trace decorator.
+     * @returns A method decorator function.
+     *
+     * @example Basic usage (always child if a parent exists)
+     * ```ts
+     * class OrderService {
+     *   @Traces.trace({
+     *     spanName: 'processOrder',
+     *     attributes: { service: 'order' },
+     *     startMode: 'createChild',
+     *     moduleName: 'order-service'
+     *   })
+     *   async processOrder(orderId: string) { ...  }
+     * }
+     * ```
+     * @example Basic usage with dynamic attributes
+     * ```ts
+     * class OrderService {
+     *  @Traces.trace({
+     *   spanName: 'processOrder',
+     *  attributes: { service: 'order' },
+     *  dynamicAttributes: (args) => ({ orderId: args[0] }),
+     * startMode: 'createChild',
+     * moduleName: 'order-service'
+     * })
+     * async processOrder(orderId: string) { ...  }
+     * }
+     * ```
+     * @example Conditional tracing by flag and arguments
+     * ```ts
+     * @Traces.trace({
+     *   startMode: 'reuse',
+     *   traceOnlyIf: (args) => process.env.ENABLE_TRACING === '1'
+     * })
+     * function computeTotal(cart: Cart) {  ... *}
+     * ```
+     */
+    static trace(options: TraceDecoratorOptions = { startMode: 'reuse', traceOnlyIf: true }) {
+        const factory: any = (...decoratorArgs: any[]) => {
+            if (
+                decoratorArgs.length === 2 &&
+                typeof decoratorArgs[0] === 'function' &&
+                decoratorArgs[1] &&
+                typeof decoratorArgs[1] === 'object' &&
+                'kind' in decoratorArgs[1]
+            ) {
+                const value: Function = decoratorArgs[0];
+                const ctx: {
+                    kind: 'method' | 'getter' | 'setter' | 'field' | 'auto-accessor';
+                    name: string | symbol;
+                    static?: boolean;
+                    private?: boolean;
+                    addInitializer?: (init: () => void) => void;
+                    access?: {
+                        get?: (thisArg: any) => any;
+                        set?: (thisArg: any, v: any) => void;
+                        has?: (thisArg: any) => boolean;
+                    };
+                    metadata?: unknown;
+                } = decoratorArgs[1];
+                if (ctx.kind === 'field') {
+                    const inferredName = typeof ctx.name === 'string' ? ctx.name : 'anonymous';
+                    const inferredModule = getCallerFile();
+                    return function (initialValue: unknown) {
+                        if (typeof initialValue !== 'function') return initialValue;
+                        const wrapped = Traces._wrapCallableWithTracing(
+                            initialValue as any,
+                            options,
+                            inferredName,
+                            inferredModule
+                        );
+                        return wrapped;
+                    };
                 }
 
-                if (options.dynamicAttributes) {
-                    dynamicLabels = options.dynamicAttributes(args);
-                }
-
-                const { span, createdSpan } = Traces.getCurrentSpanOrCreateNew(
-                    spanName,
-                    {
-                        attributes: {
-                            ...(options.attributes || {}),
-                            ...(dynamicLabels || {})
+                if (ctx.kind === 'auto-accessor') {
+                    const inferredName = typeof ctx.name === 'string' ? ctx.name : 'anonymous';
+                    const inferredModule = getCallerFile();
+                    return {
+                        init(initialValue: unknown) {
+                            if (typeof initialValue !== 'function') return initialValue;
+                            const wrapped = Traces._wrapCallableWithTracing(
+                                initialValue as any,
+                                options,
+                                inferredName,
+                                inferredModule
+                            );
+                            return wrapped;
                         }
-                    },
-                    options.createNewSpan,
-                    moduleName
-                );
-
-                let spanEnded = false;
-
-                const endSpan = () => {
-                    if (!spanEnded && createdSpan) {
-                        span.end();
-                        spanEnded = true;
-                    }
-                };
-
-                try {
-                    return context.with(trace.setSpan(context.active(), span), async () => {
-                        const result = originalMethod.apply(this, args);
-
-                        if (result instanceof Promise) {
-                            try {
-                                const res = await result;
-                                span.setStatus({ code: SpanStatusCode.OK });
-                                return res;
-                            } catch (error: any) {
-                                span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-                                span.recordException(error);
-                                throw error;
-                            } finally {
-                                endSpan();
-                            }
-                        } else {
-                            span.setStatus({ code: SpanStatusCode.OK });
-                            endSpan();
-                            return result;
-                        }
-                    });
-                } catch (error: any) {
-                    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-                    span.recordException(error);
-                    endSpan();
-                    throw error;
+                    };
                 }
-            };
 
-            return descriptor;
-        };
-    };
+                if (ctx.kind === 'method' || ctx.kind === 'getter' || ctx.kind === 'setter') {
+                    const inferredName = typeof ctx.name === 'string' ? ctx.name : 'anonymous';
+                    const inferredModule = getCallerFile();
 
-    static withTracing<T extends FunctionToTrace>(fn: T, options: TraceDecoratorOptions = {}): T {
-        const {
-            spanName = fn.name,
-            attributes = {},
-            dynamicAttributes,
-            createNewSpan = false,
-            moduleName = getCallerFile()
-        } = options;
+                    const wrapped = Traces._wrapCallableWithTracing(
+                        value as any,
+                        options,
+                        inferredName,
+                        inferredModule
+                    );
 
-        const spanNameFinal = spanName || fn.name;
-
-        return function (...args: Parameters<T>): ReturnType<T> | Promise<ReturnType<T>> {
-            const dynamicAttrs = dynamicAttributes ? dynamicAttributes(args) : {};
-            const spanOptions = {
-                attributes: {
-                    ...attributes,
-                    ...dynamicAttrs
+                    return wrapped;
                 }
-            };
-            if (fn.name !== '') {
-                spanOptions.attributes['function.name'] = fn.name;
+
+                return value;
             }
 
-            // Create a new Span for this function call
-            const { span, createdSpan } = Traces.getCurrentSpanOrCreateNew(
-                spanNameFinal,
-                {
-                    attributes: spanOptions.attributes
-                },
-                createNewSpan,
-                moduleName
-            );
+            if (
+                decoratorArgs.length === 3 &&
+                typeof decoratorArgs[1] !== 'undefined' &&
+                decoratorArgs[2] &&
+                typeof decoratorArgs[2] === 'object'
+            ) {
+                const target = decoratorArgs[0];
+                const propertyKey: string | symbol = decoratorArgs[1];
+                const descriptor: PropertyDescriptor = decoratorArgs[2];
+
+                if (!descriptor) {
+                    throw new Error(
+                        `@Traces.trace can only decorate methods/getters/setters with legacy decorators. For class fields, enable the new TC39 decorators or convert to a method.`
+                    );
+                }
+
+                const originalMethod = descriptor.value ?? descriptor.get ?? descriptor.set;
+                if (typeof originalMethod !== 'function') return descriptor;
+
+                const moduleName = options.moduleName || target?.constructor?.name || getCallerFile();
+                const spanName = options.spanName || (typeof propertyKey === 'string' ? propertyKey : 'anonymous');
+
+                const wrapped = Traces._wrapCallableWithTracing(originalMethod, options, spanName, moduleName);
+
+                if (descriptor.value) descriptor.value = wrapped;
+                else if (descriptor.get) descriptor.get = wrapped;
+                else if (descriptor.set) descriptor.set = wrapped;
+
+                return descriptor;
+            }
+
+            return decoratorArgs[2];
+        };
+
+        return factory;
+    }
+
+    private static _wrapCallableWithTracing<T extends (...a: any[]) => any>(
+        originalFn: T,
+        options: TraceDecoratorOptions,
+        inferredSpanName: string,
+        inferredModuleName: string
+    ): T {
+        const {
+            spanName = inferredSpanName || originalFn.name || 'anonymous',
+            attributes = {},
+            dynamicAttributes,
+            startMode = options.createNewSpan ? 'createChild' : options.startMode ?? 'reuse',
+            traceOnlyIf = true,
+            moduleName = inferredModuleName || getCallerFile()
+        } = options;
+
+        const globalLegacy = getTracingMode() === 'legacy-always-promise';
+        const coerceToPromise = globalLegacy;
+
+        const wrapped = function (this: any, ...args: any[]) {
+            const currentSpan = Traces.getCurrentSpan();
+            const shouldTrace =
+                typeof traceOnlyIf === 'function' ? traceOnlyIf(args, this, currentSpan) : !!traceOnlyIf;
+
+            if (!shouldTrace) {
+                const res = originalFn.apply(this, args);
+                return coerceToPromise ? Promise.resolve(res) : res;
+            }
+
+            const dyn = dynamicAttributes ? dynamicAttributes(args) : {};
+            const spanOptions: SpanOptions = {
+                attributes: {
+                    ...attributes,
+                    ...dyn,
+                    ...(originalFn.name ? { 'function.name': originalFn.name } : {})
+                }
+            };
+
+            const { span, createdSpan } = Traces.getSpan(spanName, spanOptions, startMode, moduleName);
 
             let spanEnded = false;
-
             const endSpan = () => {
                 if (!spanEnded && createdSpan) {
                     span.end();
@@ -198,28 +501,125 @@ export class Traces {
             };
 
             try {
-                const result = context.with(trace.setSpan(context.active(), span), async () => fn(...args));
-                return result
-                    .then((res) => {
-                        // Check if the result is another function and trace it
-                        span.setStatus({ code: SpanStatusCode.OK });
-                        return res;
-                    })
-                    .catch((error) => {
-                        span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-                        span.recordException(error);
-                        throw error;
-                    })
-                    .finally(() => {
-                        endSpan();
-                    });
+                const result = context.with(trace.setSpan(context.active(), span), () => {
+                    return originalFn.apply(this, args);
+                });
+
+                const isThenable = result && typeof (result as any).then === 'function';
+
+                if (isThenable) {
+                    return (result as Promise<any>)
+                        .then((res) => {
+                            span.setStatus({ code: SpanStatusCode.OK });
+                            return res;
+                        })
+                        .catch((error: any) => {
+                            span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message });
+                            span.recordException(error);
+                            throw error;
+                        })
+                        .finally(() => {
+                            endSpan();
+                        });
+                } else {
+                    span.setStatus({ code: SpanStatusCode.OK });
+                    endSpan();
+                    return coerceToPromise ? Promise.resolve(result) : result;
+                }
             } catch (error: any) {
-                span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+                span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message });
                 span.recordException(error);
                 endSpan();
+                if (coerceToPromise) return Promise.reject(error);
                 throw error;
             }
-        } as T;
+        };
+
+        return wrapped as unknown as T;
+    }
+
+    static withTracing<T extends FunctionToTrace>(fn: T, options: TraceDecoratorOptions = {}): T {
+        const {
+            spanName = fn.name || 'anonymous',
+            attributes = {},
+            dynamicAttributes,
+            startMode = options.createNewSpan ? 'createChild' : options.startMode ?? 'reuse',
+            traceOnlyIf = true,
+            moduleName = getCallerFile()
+        } = options;
+
+        const globalLegacy = getTracingMode() === 'legacy-always-promise';
+        const coerceToPromise = globalLegacy;
+
+        const wrapped = function (
+            this: ThisParameterType<T>,
+            ...args: Parameters<T>
+        ): ReturnType<T> | Promise<ReturnType<T>> {
+            const currentSpan = Traces.getCurrentSpan();
+            const shouldTrace =
+                typeof traceOnlyIf === 'function' ? traceOnlyIf(args, this, currentSpan) : !!traceOnlyIf;
+
+            if (!shouldTrace) {
+                const res = fn.apply(this, args);
+                return coerceToPromise ? Promise.resolve(res) : res;
+            }
+
+            const dyn = dynamicAttributes ? dynamicAttributes(args) : {};
+            const spanOptions: SpanOptions = {
+                attributes: {
+                    ...attributes,
+                    ...dyn,
+                    ...(fn.name ? { 'function.name': fn.name } : {})
+                }
+            };
+
+            const { span, createdSpan } = Traces.getSpan(spanName, spanOptions, startMode, moduleName);
+
+            let spanEnded = false;
+            const endSpan = () => {
+                if (!spanEnded && createdSpan) {
+                    span.end();
+                    spanEnded = true;
+                }
+            };
+
+            try {
+                const result = context.with(trace.setSpan(context.active(), span), () => {
+                    return fn.apply(this, args);
+                });
+
+                const isThenable = result && typeof (result as any).then === 'function';
+
+                if (isThenable) {
+                    // Promise-Fall
+                    return (result as Promise<ReturnType<T>>)
+                        .then((res) => {
+                            span.setStatus({ code: SpanStatusCode.OK });
+                            return res;
+                        })
+                        .catch((error: any) => {
+                            span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message });
+                            span.recordException(error);
+                            throw error;
+                        })
+                        .finally(() => {
+                            endSpan();
+                        });
+                } else {
+                    span.setStatus({ code: SpanStatusCode.OK });
+                    endSpan();
+                    return coerceToPromise ? Promise.resolve(result as ReturnType<T>) : (result as ReturnType<T>);
+                }
+            } catch (error: any) {
+                span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message });
+                span.recordException(error);
+                endSpan();
+                if (coerceToPromise) return Promise.reject(error);
+                throw error;
+            }
+        };
+
+        return wrapped as unknown as T;
     }
 
     private static _setSamplingRule(spanOption: SpanOptions | undefined): SpanOptions {

--- a/src/util/httpUtils.ts
+++ b/src/util/httpUtils.ts
@@ -10,7 +10,6 @@ export function isKnownRoute(req: Request): boolean {
     return req.app._router.stack.some((layer: Layer) => {
         if (!layer.route || !layer.route.path) return false;
 
-        // Ersetze die Platzhalter durch Regex
         const routeRegex = new RegExp('^' + layer.route.path.replace(/:\w+/g, '[^/]+') + '$');
 
         return routeRegex.test(sanitizedPath);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -22,7 +22,7 @@ export function getCallerFile() {
             }
         }
     } catch (e) {
-        // Fallback handling
+        // ignore
     }
 
     Error.prepareStackTrace = originalFunc;

--- a/test/metrics/metrics.test.ts
+++ b/test/metrics/metrics.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { register, Counter, Gauge, Histogram, Summary, collectDefaultMetrics } from 'prom-client';
+
+import { Metrics } from '../../src/metrics/metricsDecorator.ts';
+import { metrics, createMetric, MetricType } from '../../src/metrics/metrics.ts';
+import * as PromClient from 'prom-client';
+
+beforeEach(() => {
+    register.clear();
+    Metrics.clear();
+});
+
+describe('Counter registration / lazy creation / increment', () => {
+    it('creates lazily and increments with label conversion', async () => {
+        Metrics.registerCounter({
+            name: 'test_counter_total',
+            help: 'test counter',
+            labelNames: ['a', 'b', 'flag']
+        });
+
+        expect(register.getSingleMetric('test_counter_total')).toBeUndefined();
+
+        Metrics.incrementCounter('test_counter_total', { a: 'X', b: 2, flag: true, ignore: undefined }, 3);
+
+        const metric = register.getSingleMetric('test_counter_total') as Counter<string>;
+        expect(metric).toBeInstanceOf(Counter);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'test_counter_total')!;
+        expect(m.type).toBe('counter');
+
+        const sample = m.values.find((v: any) => v.labels.a === 'X' && v.labels.b === 2 && v.labels.flag === 'true');
+        expect(sample?.value).toBe(3);
+    });
+
+    it('throws if incrementing an unknown counter', () => {
+        expect(() => Metrics.incrementCounter('does_not_exist')).toThrow(/Counter with name does_not_exist not found/);
+    });
+});
+
+describe('@Metrics.counter decorator', () => {
+    it('increments with error="none" on success and error="<name>" on throw (sync)', async () => {
+        class S {
+            @Metrics.counter({
+                metricName: 'dec_sync_total',
+                help: 'dec sync',
+                labels: { static: '1' },
+                dynamicLabels: (args) => ({ arg0: String(args[0]) })
+            })
+            run(x: number) {
+                if (x < 0) throw new RangeError('neg');
+                return x + 1;
+            }
+        }
+        const s = new S();
+
+        expect(s.run(1)).toBe(2);
+        try {
+            s.run(-1);
+        } catch {}
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_sync_total')!;
+        const ok = m.values.find(
+            (v: any) => v.labels.error === 'none' && v.labels.static === '1' && v.labels.arg0 === '1'
+        );
+        const err = m.values.find((v: any) => v.labels.error === 'RangeError' && v.labels.arg0 === '-1');
+        expect(ok?.value).toBe(1);
+        expect(err?.value).toBe(1);
+    });
+
+    it('works with async function and sets error label on rejection', async () => {
+        class S {
+            @Metrics.counter({
+                metricName: 'dec_async_total',
+                help: 'dec async',
+                dynamicLabels: (args) => ({ id: String(args[0]) })
+            })
+            async run(id: number) {
+                if (id === 42) throw new Error('boom');
+                return 'ok';
+            }
+        }
+        const s = new S();
+
+        await s.run(1).then((v) => expect(v).toBe('ok'));
+        await expect(s.run(42)).rejects.toThrow('boom');
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_async_total')!;
+        const ok = m.values.find((v: any) => v.labels.error === 'none' && v.labels.id === '1');
+        const err = m.values.find((v: any) => v.labels.error === 'Error' && v.labels.id === '42');
+        expect(ok?.value).toBe(1);
+        expect(err?.value).toBe(1);
+    });
+});
+
+describe('Gauge registration / set / startTimer', () => {
+    it('sets value with boolean label conversion', async () => {
+        Metrics.registerGauge({
+            name: 'test_gauge',
+            help: 'g',
+            labelNames: ['flag', 'x']
+        });
+
+        Metrics.setGauge('test_gauge', 7, { flag: false, x: 3 });
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'test_gauge')!;
+        const s = m.values.find((v: any) => v.labels.flag === 'false' && v.labels.x === 3);
+        expect(s?.value).toBe(7);
+    });
+
+    it('startGaugeTimer returns end function and records duration in seconds', async () => {
+        Metrics.registerGauge({ name: 'timed_gauge', help: 'tg' });
+
+        const end = Metrics.startGaugeTimer('timed_gauge');
+        await new Promise((r) => setTimeout(r, 10));
+        end();
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'timed_gauge')!;
+        const s = m.values[0];
+        expect(typeof s.value).toBe('number');
+        expect(s.value).toBeGreaterThan(0);
+    });
+});
+
+describe('@Metrics.gauge decorator', () => {
+    it('timed=false: sets gauge from numeric return', async () => {
+        class S {
+            @Metrics.gauge({ metricName: 'dec_gauge', help: 'dg', labels: { stat: '1' } }, false)
+            compute(n: number) {
+                return n * 2;
+            }
+        }
+        const s = new S();
+        expect(s.compute(5)).toBe(10);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_gauge')!;
+        const s1 = m.values.find((v: any) => v.labels.stat === '1');
+        expect(s1?.value).toBe(10);
+    });
+
+    it('timed=true: records duration, does not overwrite with return value', async () => {
+        class S {
+            @Metrics.gauge({ metricName: 'dec_gauge_time', help: 'dgt' }, true)
+            async work() {
+                await new Promise((r) => setTimeout(r, 5));
+                return 123;
+            }
+        }
+        const s = new S();
+        await s.work();
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_gauge_time')!;
+        const s1 = m.values[0];
+        expect(s1.value).toBeGreaterThan(0);
+        expect(s1.value).toBeLessThan(1);
+    });
+});
+
+describe('Histogram registration / observe', () => {
+    it('uses default buckets if none specified and observe() records', async () => {
+        Metrics.registerHistogram({ name: 'h1', help: 'h' });
+        Metrics.observeHistogram('h1', 0.2, { a: 'b' });
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'h1')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        const sum = m.values.find((v: any) => v.metricName?.endsWith('_sum'));
+        expect(count?.value).toBeGreaterThan(0);
+        expect(sum?.value).toBeGreaterThan(0);
+    });
+});
+
+describe('@Metrics.histogram decorator', () => {
+    it('times the method and sets error label on throw', async () => {
+        class S {
+            @Metrics.histogram({
+                metricName: 'dec_hist',
+                help: 'd-h',
+                labels: { svc: 'x' },
+                dynamicLabels: (a) => ({ arg0: String(a[0]) }),
+                buckets: [0.001, 0.01, 0.1, 1]
+            })
+            async run(x: number) {
+                if (x < 0) throw new Error('bad');
+                await new Promise((r) => setTimeout(r, 5));
+                return 'ok';
+            }
+        }
+        const s = new S();
+        await s.run(1);
+        await expect(s.run(-1)).rejects.toThrow('bad');
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_hist')!;
+
+        const counts = m.values.filter((v: any) => v.metricName?.endsWith('_count'));
+        const total = counts.reduce((acc: number, s: any) => acc + (s.value || 0), 0);
+        expect(total).toBeGreaterThanOrEqual(2);
+    });
+});
+
+describe('Summary registration / observe', () => {
+    it('observes values and exposes quantiles', async () => {
+        Metrics.registerSummary({ name: 'sum1', help: 's' });
+        Metrics.observeSummary('sum1', 1.0);
+        Metrics.observeSummary('sum1', 2.0);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'sum1')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        const sum = m.values.find((v: any) => v.metricName?.endsWith('_sum'));
+        expect(count?.value).toBeGreaterThanOrEqual(2);
+        expect(sum?.value).toBeGreaterThan(0);
+    });
+});
+
+describe('@Metrics.summary decorator', () => {
+    it('timed=false: observes numeric return value', async () => {
+        class S {
+            @Metrics.summary({ metricName: 'dec_sum', help: 'ds' }, false)
+            calc() {
+                return 7;
+            }
+        }
+        const s = new S();
+        expect(s.calc()).toBe(7);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_sum')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        const sum = m.values.find((v: any) => v.metricName?.endsWith('_sum'));
+        expect(count?.value).toBeGreaterThanOrEqual(1);
+        expect(sum?.value).toBeGreaterThanOrEqual(7);
+    });
+
+    it('timed=true: records duration via startTimer', async () => {
+        class S {
+            @Metrics.summary({ metricName: 'dec_sum_time', help: 'dst' }, true)
+            async slow() {
+                await new Promise((r) => setTimeout(r, 5));
+                return 123;
+            }
+        }
+        const s = new S();
+        await s.slow();
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'dec_sum_time')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        expect(count?.value).toBeGreaterThanOrEqual(1);
+    });
+});
+
+describe('metrics facade (getMetrics/createMetric/…)', () => {
+    it('getMetrics returns contentType and exposition string', async () => {
+        collectDefaultMetrics();
+        const out = await metrics.getMetrics();
+        expect(out.contentType).toBe(register.contentType);
+        expect(typeof out.data).toBe('string');
+        expect(out.data.length).toBeGreaterThan(0);
+    });
+
+    it('createMetric registers via type switch', () => {
+        createMetric(MetricType.Counter, { name: 'sw_cnt', help: 'x' });
+        createMetric(MetricType.Gauge, { name: 'sw_g', help: 'x' });
+        createMetric(MetricType.Histogram, { name: 'sw_h', help: 'x', buckets: [0.1, 1] });
+        createMetric(MetricType.Summary, { name: 'sw_s', help: 'x', percentiles: [0.5, 0.9] });
+
+        Metrics.incrementCounter('sw_cnt', {}, 1);
+        Metrics.setGauge('sw_g', 1);
+        Metrics.observeHistogram('sw_h', 0.5);
+        Metrics.observeSummary('sw_s', 1.5);
+
+        expect(register.getSingleMetric('sw_cnt')).toBeInstanceOf(Counter);
+        expect(register.getSingleMetric('sw_g')).toBeInstanceOf(Gauge);
+        expect(register.getSingleMetric('sw_h')).toBeInstanceOf(Histogram);
+        expect(register.getSingleMetric('sw_s')).toBeInstanceOf(Summary);
+    });
+
+    it('facade methods delegate to Metrics helpers (counter/gauge/histogram/summary)', async () => {
+        createMetric(MetricType.Counter, { name: 'fac_cnt', help: 'x', labelNames: ['a', 'flag'] });
+        metrics.incrementCounter('fac_cnt', { a: '1', flag: true }, 2);
+
+        createMetric(MetricType.Gauge, { name: 'fac_g', help: 'x' });
+        metrics.setGauge('fac_g', 11);
+
+        createMetric(MetricType.Histogram, { name: 'fac_h', help: 'x', buckets: [0.001, 0.01] });
+        metrics.observeHistogram('fac_h', 0.005);
+
+        createMetric(MetricType.Summary, { name: 'fac_s', help: 'x' });
+        metrics.observeSummary('fac_s', 3.14);
+
+        const json = await register.getMetricsAsJSON();
+        expect(json.some((j) => j.name === 'fac_cnt')).toBe(true);
+        expect(json.some((j) => j.name === 'fac_g')).toBe(true);
+        expect(json.some((j) => j.name === 'fac_h')).toBe(true);
+        expect(json.some((j) => j.name === 'fac_s')).toBe(true);
+    });
+});
+describe('TC39-style decorators (factory(value, ctx))', () => {
+    it('counter (method): increments and sets error label', async () => {
+        const dec = Metrics.counter({
+            metricName: 'tc39_counter_total',
+            help: 'tc39 counter',
+            labels: { static: '1' },
+            dynamicLabels: (args) => ({ arg0: String(args[0]) })
+        });
+
+        const original = function (x: number) {
+            if (x < 0) throw new RangeError('neg');
+            return x + 1;
+        };
+        const wrapped = dec(original, { kind: 'method', name: 'run' });
+
+        expect(wrapped(1)).toBe(2);
+        try {
+            wrapped(-1);
+        } catch {}
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_counter_total')!;
+        const ok = m.values.find(
+            (v: any) => v.labels.error === 'none' && v.labels.static === '1' && v.labels.arg0 === '1'
+        );
+        const err = m.values.find((v: any) => v.labels.error === 'RangeError' && v.labels.arg0 === '-1');
+        expect(ok?.value).toBe(1);
+        expect(err?.value).toBe(1);
+    });
+
+    it('gauge (method, timed=false): sets gauge from numeric return', async () => {
+        const dec = Metrics.gauge({ metricName: 'tc39_gauge', help: 'tc39 g' }, false);
+
+        const original = function (n: number) {
+            return n * 3;
+        };
+        const wrapped = dec(original, { kind: 'method', name: 'compute' });
+
+        expect(wrapped(4)).toBe(12);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_gauge')!;
+        const s = m.values[0];
+        expect(s.value).toBe(12);
+    });
+
+    it('gauge (method, timed=true): records duration only', async () => {
+        const dec = Metrics.gauge({ metricName: 'tc39_gauge_time', help: 'tc39 g time' }, true);
+
+        const original = async function () {
+            await new Promise((r) => setTimeout(r, 5));
+            return 777;
+        };
+        const wrapped = dec(original, { kind: 'method', name: 'work' });
+
+        await wrapped();
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_gauge_time')!;
+        const s = m.values[0];
+        expect(s.value).toBeGreaterThan(0);
+        expect(s.value).toBeLessThan(1);
+    });
+
+    it('histogram (field): times and sets error label across series', async () => {
+        const dec = Metrics.histogram({
+            metricName: 'tc39_hist',
+            help: 'tc39 h',
+            labels: { svc: 'x' },
+            dynamicLabels: (a) => ({ arg0: String(a[0]) }),
+            buckets: [0.001, 0.01, 0.1, 1]
+        });
+
+        const init = dec(function noop() {}, { kind: 'field', name: 'run' });
+        const run = init(function (x: number) {
+            if (x < 0) throw new Error('bad');
+            return 'ok';
+        });
+
+        await Promise.resolve()
+            .then(() => new Promise((r) => setTimeout(r, 5)))
+            .then(() => run(1));
+        await expect((async () => run(-1))()).rejects.toThrow('bad');
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_hist')!;
+
+        const counts = m.values.filter((v: any) => v.metricName?.endsWith('_count'));
+        const total = counts.reduce((acc: number, s: any) => acc + (s.value || 0), 0);
+        expect(total).toBeGreaterThanOrEqual(2);
+    });
+
+    it('summary (auto-accessor, timed=false): observes numeric return value', async () => {
+        const dec = Metrics.summary({ metricName: 'tc39_sum', help: 'tc39 s' }, false);
+
+        const acc = dec(function noop() {}, { kind: 'auto-accessor', name: 'calc' });
+        const calc = acc.init(function () {
+            return 13;
+        });
+
+        expect(calc()).toBe(13);
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_sum')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        const sum = m.values.find((v: any) => v.metricName?.endsWith('_sum'));
+        expect(count?.value).toBeGreaterThanOrEqual(1);
+        expect(sum?.value).toBeGreaterThanOrEqual(13);
+    });
+
+    it('summary (method, timed=true): records duration via startTimer', async () => {
+        const dec = Metrics.summary({ metricName: 'tc39_sum_time', help: 'tc39 s time' }, true);
+
+        const original = async function () {
+            await new Promise((r) => setTimeout(r, 5));
+            return 12345;
+        };
+        const wrapped = dec(original, { kind: 'method', name: 'slow' });
+
+        await wrapped();
+
+        const json = await register.getMetricsAsJSON();
+        const m = json.find((j) => j.name === 'tc39_sum_time')!;
+        const count = m.values.find((v: any) => v.metricName?.endsWith('_count'));
+        expect(count?.value).toBeGreaterThanOrEqual(1);
+    });
+});
+import { vi } from 'vitest';
+describe('http metrics middleware (e2e)', () => {
+    it('records duration, count and sum with route pattern labels', async () => {
+        await vi.resetModules();
+        Metrics.clear();
+        const express = (await import('express')).default;
+        const request = (await import('supertest')).default;
+        const { httpMetricsMiddleWare } = await import('../../src/metrics/httpMetrics.ts');
+
+        const app = express();
+        app.use(httpMetricsMiddleWare);
+
+        app.get('/users/:id', (_req: any, res: any) => res.status(200).send('ok'));
+        app.get('/health', (_req: any, res: any) => res.status(204).end());
+
+        await request(app).get('/users/123');
+        await request(app).get('/health');
+
+        const json = await register.getMetricsAsJSON();
+
+        const hJson = json.find((j) => j.name === 'http_request_duration_seconds')!;
+        const hCounts = hJson.values.filter((v: any) => v.metricName?.endsWith('_count'));
+        const hTotalCount = hCounts.reduce((acc: number, v: any) => acc + (v.value || 0), 0);
+        expect(hTotalCount).toBeGreaterThanOrEqual(2);
+
+        const cJson = json.find((j) => j.name === 'http_requests_total')!;
+        const usersRouteSample = cJson.values.find((v: any) => v.labels.route === '/users/:id');
+        const healthRouteSample = cJson.values.find((v: any) => v.labels.route === '/health');
+        expect(usersRouteSample?.value).toBeGreaterThanOrEqual(1);
+        expect(healthRouteSample?.value).toBeGreaterThanOrEqual(1);
+
+        const sJson = json.find((j) => j.name === 'http_request_duration_sum')!;
+        const sumAny = sJson.values[0];
+        expect(sumAny.value).toBeGreaterThan(0);
+    });
+});

--- a/test/tracing/decorator.test.ts
+++ b/test/tracing/decorator.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { context, trace, SpanStatusCode } from '@opentelemetry/api';
+import { exporter } from './setup-otel.ts';
+
+import { Traces } from '../../src/tracing/tracingDecorator.ts';
+
+const spans = () => exporter.getFinishedSpans();
+const reset = () => exporter.reset();
+
+describe('Decorator - new TC39-Form', () => {
+    beforeEach(reset);
+
+    it('wrapped method creates Span with Name/Attributes', async () => {
+        class Svc {
+            // @ts-ignore: Decorator-Aufruf in TS 5.x inline
+            @Traces.trace({
+                spanName: 'svc.process',
+                attributes: { svc: 'demo' },
+                dynamicAttributes: (args) => ({ x: args[0] }),
+                startMode: 'createChild',
+                moduleName: 'svc'
+            })
+            async process(x: number) {
+                return x * 3;
+            }
+        }
+        const svc = new Svc();
+
+        const tracer = trace.getTracer('test');
+        const root = tracer.startSpan('root', { root: true });
+        const res = await context.with(trace.setSpan(context.active(), root), () => svc.process(4));
+        root.end();
+
+        expect(res).toBe(12);
+        const out = spans();
+        const s = out.find((s: any) => s.name === 'svc.process')!;
+        expect(s.status.code).toBe(SpanStatusCode.OK);
+        expect(s.attributes.svc).toBe('demo');
+        expect(s.attributes.x).toBe(4);
+        expect(s.attributes['function.name']).toBe('process');
+    });
+});
+
+describe('Decorator - Legacy-Form (target, key, descriptor)', () => {
+    beforeEach(reset);
+
+    it('wrapped legacy method works', async () => {
+        class Svc {
+            process(x: number) {
+                return x + 10;
+            }
+        }
+
+        const desc = Object.getOwnPropertyDescriptor(Svc.prototype, 'process')!;
+        const newDesc = (
+            Traces.trace({
+                spanName: 'svc.legacy',
+                startMode: 'createChild',
+                moduleName: 'svc'
+            }) as any
+        )(Svc.prototype, 'process', desc);
+        Object.defineProperty(Svc.prototype, 'process', newDesc);
+
+        const svc = new Svc();
+        const tracer = trace.getTracer('test');
+        const root = tracer.startSpan('root', { root: true });
+        const res = await context.with(trace.setSpan(context.active(), root), () => svc.process(5));
+        root.end();
+
+        expect(res).toBe(15);
+        const out = spans();
+        const s = out.find((s: any) => s.name === 'svc.legacy')!;
+        expect(s.status.code).toBe(SpanStatusCode.OK);
+        expect(s.attributes['function.name']).toBe('process');
+    });
+});

--- a/test/tracing/instrumentation.test.ts
+++ b/test/tracing/instrumentation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import { initInstrumentation, shutDownInstrumentation } from '../../src/instrumentation.ts';
+import { BatchSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+describe('NodeSDK init/shutdown (integration, ohne Netz)', () => {
+    it('init mit Default -> no-op Exporter (kein Throw) & shutdown ohne Fehler', async () => {
+        const { sdk, traceExporter, spanProcessors } = initInstrumentation({
+            serviceName: 'svc-default',
+            instrumentations: []
+        });
+
+        expect(sdk).toBeTruthy();
+        expect(traceExporter).toBeTruthy();
+        expect(spanProcessors === undefined || Array.isArray(spanProcessors)).toBe(true);
+
+        await shutDownInstrumentation();
+    });
+
+    it('init mit localDebugging=true -> ConsoleSpanExporter', async () => {
+        const { traceExporter } = initInstrumentation({
+            serviceName: 'svc-console',
+            localDebugging: true,
+            instrumentations: []
+        });
+
+        expect(traceExporter).toBeInstanceOf(ConsoleSpanExporter);
+        await shutDownInstrumentation();
+    });
+
+    it('init mit OTLP URL -> OTLPTraceExporter konstruiert', async () => {
+        const { traceExporter } = initInstrumentation({
+            serviceName: 'svc-otlp',
+            url: 'http://localhost:4318/v1/traces',
+            instrumentations: [],
+            concurrencyLimit: 5
+        });
+
+        expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
+        await shutDownInstrumentation();
+    });
+
+    it('spanLimits: werden am Provider wirksam (Count-/Length-Limits, Events, Links)', async () => {
+        initInstrumentation({
+            serviceName: 'svc-limits',
+            instrumentations: [],
+            spanLimits: {
+                attributeCountLimit: 2,
+                attributeValueLengthLimit: 4,
+                eventCountLimit: 1,
+                linkCountLimit: 1,
+                attributePerEventCountLimit: 1,
+                attributePerLinkCountLimit: 1
+            }
+        });
+
+        const { trace } = await import('@opentelemetry/api');
+        const tracer = trace.getTracer('limits-test');
+
+        const pA = tracer.startSpan('parentA', { root: true });
+        const pB = tracer.startSpan('parentB', { root: true });
+        const pC = tracer.startSpan('parentC', { root: true });
+
+        const span: any = tracer.startSpan('limited', {
+            links: [
+                { context: pA.spanContext(), attributes: { a: 1, b: 2 } },
+                { context: pB.spanContext(), attributes: { c: 3, d: 4 } },
+                { context: pC.spanContext() }
+            ],
+            root: true
+        });
+
+        span.setAttribute('k1', '1234567');
+        span.setAttribute('k2', 'X');
+        span.setAttribute('k3', 'Y');
+
+        span.addEvent('e2');
+        span.addEvent('e1', { a: 1, b: 2 });
+
+        expect(span._spanLimits.attributeCountLimit).toBe(2);
+        expect(span._spanLimits.attributeValueLengthLimit).toBe(4);
+        expect(span._spanLimits.eventCountLimit).toBe(1);
+        expect(span._spanLimits.linkCountLimit).toBe(1);
+
+        const attr = span.attributes ?? {};
+        expect(Object.keys(attr)).toHaveLength(2);
+        expect(attr['k1']).toBe('1234');
+        expect(span._droppedAttributesCount).toBeGreaterThanOrEqual(1);
+
+        const evts = span.events ?? [];
+        expect(evts).toHaveLength(1);
+        expect(evts[0].name).toBe('e1');
+
+        const lnks = span.links ?? [];
+        expect(Array.isArray(lnks)).toBe(true);
+        expect(lnks.length).toBeGreaterThan(0);
+        expect(span._droppedLinksCount).toBeGreaterThanOrEqual(0);
+
+        span.end();
+        pA.end();
+        pB.end();
+        pC.end();
+        await shutDownInstrumentation();
+    });
+
+    describe('NodeSDK init/shutdown – Exporter/Processor precedence (integration, offline)', () => {
+        it('exporter descriptor: console -> ConsoleSpanExporter + default BatchSpanProcessor', async () => {
+            const { traceExporter, spanProcessors } = initInstrumentation({
+                serviceName: 'svc-exporter-console',
+                instrumentations: [],
+                exporter: { kind: 'console' }
+            });
+
+            expect(traceExporter).toBeInstanceOf(ConsoleSpanExporter);
+            // Library should attach a default BatchSpanProcessor when exporter is provided
+            expect(Array.isArray(spanProcessors)).toBe(true);
+            expect(spanProcessors!.some((p) => p instanceof BatchSpanProcessor)).toBe(true);
+
+            await shutDownInstrumentation();
+        });
+
+        it('exporter descriptor: otlp -> OTLPTraceExporter + default BatchSpanProcessor (no network I/O expected)', async () => {
+            const { traceExporter, spanProcessors } = initInstrumentation({
+                serviceName: 'svc-exporter-otlp',
+                instrumentations: [],
+                exporter: { kind: 'otlp', url: 'http://localhost:4318/v1/traces', concurrencyLimit: 3 }
+            });
+
+            expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
+            expect(Array.isArray(spanProcessors)).toBe(true);
+            expect(spanProcessors!.some((p) => p instanceof BatchSpanProcessor)).toBe(true);
+
+            await shutDownInstrumentation();
+        });
+
+        it('exporter descriptor: noop -> noop exporter; no processors attached', async () => {
+            const { traceExporter, spanProcessors } = initInstrumentation({
+                serviceName: 'svc-exporter-noop',
+                instrumentations: [],
+                exporter: { kind: 'noop' }
+            });
+
+            expect(traceExporter).not.toBeInstanceOf(ConsoleSpanExporter);
+            expect(traceExporter).not.toBeInstanceOf(OTLPTraceExporter);
+
+            expect(spanProcessors === undefined || (Array.isArray(spanProcessors) && spanProcessors.length === 0)).toBe(
+                true
+            );
+
+            await shutDownInstrumentation();
+        });
+
+        it('concrete SpanExporter instance + no spanProcessors -> library creates default BatchSpanProcessor', async () => {
+            const exporter = new ConsoleSpanExporter();
+            const { traceExporter, spanProcessors } = initInstrumentation({
+                serviceName: 'svc-exporter-instance',
+                instrumentations: [],
+                exporter
+            });
+
+            expect(traceExporter).toBe(exporter);
+            expect(Array.isArray(spanProcessors)).toBe(true);
+            expect(spanProcessors!.length).toBeGreaterThanOrEqual(1);
+            expect(spanProcessors!.some((p) => p instanceof BatchSpanProcessor)).toBe(true);
+
+            await shutDownInstrumentation();
+        });
+
+        it('explicit spanProcessors -> processors used as-is (no implicit defaults added)', async () => {
+            const custom = new BatchSpanProcessor(new ConsoleSpanExporter());
+            const { spanProcessors, traceExporter } = initInstrumentation({
+                serviceName: 'svc-explicit-processors',
+                instrumentations: [],
+                spanProcessors: [custom]
+                // exporter intentionally omitted
+            });
+
+            expect(Array.isArray(spanProcessors)).toBe(true);
+            expect(spanProcessors!.length).toBe(1);
+            expect(spanProcessors![0]).toBe(custom);
+            expect(spanProcessors!.filter((p) => p instanceof BatchSpanProcessor).length).toBe(1);
+
+            await shutDownInstrumentation();
+        });
+
+        it('legacy flags (url/localDebugging) still work but are deprecated: url -> OTLP, localDebugging -> Console', async () => {
+            {
+                const { traceExporter, spanProcessors } = initInstrumentation({
+                    serviceName: 'svc-legacy-console',
+                    instrumentations: [],
+                    localDebugging: true
+                });
+                expect(traceExporter).toBeInstanceOf(ConsoleSpanExporter);
+                expect(Array.isArray(spanProcessors)).toBe(true);
+                expect(spanProcessors!.some((p) => p instanceof BatchSpanProcessor)).toBe(true);
+                await shutDownInstrumentation();
+            }
+
+            {
+                const { traceExporter, spanProcessors } = initInstrumentation({
+                    serviceName: 'svc-legacy-otlp',
+                    instrumentations: [],
+                    url: 'http://localhost:4318/v1/traces',
+                    concurrencyLimit: 2
+                });
+                expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
+                expect(Array.isArray(spanProcessors)).toBe(true);
+                expect(spanProcessors!.some((p) => p instanceof BatchSpanProcessor)).toBe(true);
+                await shutDownInstrumentation();
+            }
+        });
+    });
+});

--- a/test/tracing/setup-otel.ts
+++ b/test/tracing/setup-otel.ts
@@ -1,0 +1,24 @@
+import { beforeAll, afterAll } from 'vitest';
+import { trace, context } from '@opentelemetry/api';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+
+export const exporter = new InMemorySpanExporter();
+
+const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)]
+});
+
+let cm: AsyncLocalStorageContextManager;
+
+beforeAll(() => {
+    trace.setGlobalTracerProvider(provider);
+    cm = new AsyncLocalStorageContextManager();
+    context.setGlobalContextManager(cm);
+});
+
+afterAll(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    cm.disable();
+});

--- a/test/tracing/traces.test.ts
+++ b/test/tracing/traces.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { context, trace, SpanStatusCode } from '@opentelemetry/api';
+import { exporter } from './setup-otel.ts';
+
+import { Traces } from '../../src/tracing/tracingDecorator.ts';
+import { setTracingMode } from '../../src/tracing/tracing-config.ts';
+
+const spans = () => exporter.getFinishedSpans();
+const reset = () => exporter.reset();
+
+describe('Traces.getSpan - StartModes', () => {
+    beforeEach(reset);
+
+    it('reuse: ohne aktiven Span -> neuer Span', () => {
+        const { span, createdSpan } = Traces.getSpan('root-reuse');
+        expect(createdSpan).toBe(true);
+        span.end();
+
+        const out = spans();
+        expect(out).toHaveLength(1);
+        expect(out[0].name).toBe('root-reuse');
+        expect(out[0].attributes['otel.collector.sampling.keep']).toBe(false);
+    });
+
+    it('reuse: mit aktivem Span -> re-use, kein neuer', () => {
+        const tracer = trace.getTracer('test');
+        const parent = tracer.startSpan('parent', { root: true });
+
+        const res = context.with(trace.setSpan(context.active(), parent), () => {
+            return Traces.getSpan('ignored', {}, 'reuse', 'test');
+        });
+
+        expect(res.createdSpan).toBe(false);
+        expect(res.span).toBe(parent);
+
+        parent.end();
+        const out = spans();
+        expect(out).toHaveLength(1);
+        expect(out[0].name).toBe('parent');
+    });
+
+    it('createChild: Parent aktiv -> gleicher traceId & parentSpanId gesetzt', () => {
+        const tracer = trace.getTracer('test');
+        const parent = tracer.startSpan('p', { root: true });
+
+        context.with(trace.setSpan(context.active(), parent), () => {
+            const { span } = Traces.getSpan('child', {}, 'createChild');
+            span.end();
+        });
+        parent.end();
+
+        const out = spans();
+        const p = out.find((s: any) => s.name === 'p')!;
+        const c = out.find((s: any) => s.name === 'child')!;
+        expect(c.spanContext().traceId).toBe(p.spanContext().traceId);
+        expect(c.parentSpanContext!.spanId).toBe(p.spanContext().spanId);
+    });
+
+    it('newTrace: neuer Root (andere traceId, kein parentSpanId)', () => {
+        const tracer = trace.getTracer('test');
+        const parent = tracer.startSpan('p', { root: true });
+
+        context.with(trace.setSpan(context.active(), parent), () => {
+            const { span } = Traces.getSpan('independent', {}, 'newTrace');
+            span.end();
+        });
+        parent.end();
+
+        const out = spans();
+        const p = out.find((s: any) => s.name === 'p')!;
+        const n = out.find((s: any) => s.name === 'independent')!;
+        expect(n.spanContext().traceId).not.toBe(p.spanContext().traceId);
+        expect(n.parentSpanContext).toBeUndefined();
+    });
+
+    it('newTraceWithLink: neuer Root (wir prüfen neue traceId; Links optional)', () => {
+        const tracer = trace.getTracer('test');
+        const parent = tracer.startSpan('p', { root: true });
+
+        context.with(trace.setSpan(context.active(), parent), () => {
+            const { span } = Traces.getSpan('linked', {}, 'newTraceWithLink');
+            span.end();
+        });
+        parent.end();
+
+        const out = spans();
+        const p = out.find((s: any) => s.name === 'p')!;
+        const l = out.find((s: any) => s.name === 'linked')!;
+        expect(l.spanContext().traceId).not.toBe(p.spanContext().traceId);
+        expect(l.parentSpanContext).toBeUndefined();
+
+        expect(l.links?.[0]?.context.traceId).toBe(p.spanContext().traceId);
+        expect(l.links?.[0]?.context.spanId).toBe(p.spanContext().spanId);
+    });
+});
+
+describe('withTracing - Status/Exceptions/Attribute', () => {
+    beforeEach(reset);
+
+    it('OK-Status + Attribute-Merge + function.name', async () => {
+        function add(a: number, b: number) {
+            return a + b;
+        }
+        const wrapped = Traces.withTracing(add, {
+            spanName: 'sum',
+            attributes: { static: 1 },
+            dynamicAttributes: (args) => ({ a: args[0], b: args[1] }),
+            startMode: 'createChild',
+            moduleName: 'calc'
+        });
+
+        const tracer = trace.getTracer('test');
+        const root = tracer.startSpan('root', { root: true });
+        const result = await context.with(trace.setSpan(context.active(), root), () => wrapped(2, 3));
+        root.end();
+
+        expect(result).toBe(5);
+        const out = spans();
+        const s = out.find((s: any) => s.name === 'sum')!;
+        expect(s.status.code).toBe(SpanStatusCode.OK);
+        expect(s.attributes.static).toBe(1);
+        expect(s.attributes.a).toBe(2);
+        expect(s.attributes.b).toBe(3);
+        expect(s.attributes['function.name']).toBe('add');
+    });
+
+    it('Exception -> Status ERROR + exception-Event', async () => {
+        function boom() {
+            throw new Error('kaputt');
+        }
+        const wrapped = Traces.withTracing(boom, { spanName: 'boom', startMode: 'createChild' });
+
+        const tracer = trace.getTracer('test');
+        const root = tracer.startSpan('root', { root: true });
+
+        await expect(async () => {
+            await context.with(trace.setSpan(context.active(), root), () => Promise.resolve().then(() => wrapped()));
+        }).rejects.toThrow('kaputt');
+
+        root.end();
+
+        const out = spans();
+        const b = out.find((s: any) => s.name === 'boom')!;
+        expect(b.status.code).toBe(SpanStatusCode.ERROR);
+        expect(b.events.some((e: any) => e.name === 'exception')).toBe(true);
+    });
+
+    it('traceOnlyIf=false -> erzeugt keinen Span', () => {
+        const fn = (x: number) => x * 2;
+        const wrapped = Traces.withTracing(fn, { traceOnlyIf: false, spanName: 'nope' });
+        const res = wrapped(7);
+        expect(res).toBe(14);
+        expect(spans()).toHaveLength(0);
+    });
+
+    it('legacy-always-promise -> sync Ergebnis wird zu Promise', async () => {
+        setTracingMode('legacy-always-promise');
+        const fn = (x: number) => x + 1;
+        const wrapped = Traces.withTracing(fn, { spanName: 'legacy' });
+        const val = await wrapped(5);
+        expect(val).toBe(6);
+    });
+});
+
+describe('Sampling-Attribut (_setSamplingRule)', () => {
+    beforeEach(reset);
+
+    it('setzt otel.collector.sampling.keep=false, falls nicht gesetzt', () => {
+        const { span } = Traces.getSpan('sample-default');
+        span.end();
+        const out = spans();
+        expect(out[0].attributes['otel.collector.sampling.keep']).toBe(false);
+    });
+
+    it('übernimmt true, wenn explizit gesetzt', () => {
+        const { span } = Traces.getSpan('sample-true', {
+            attributes: { 'otel.collector.sampling.keep': true }
+        });
+        span.end();
+        const out = spans();
+        expect(out[0].attributes['otel.collector.sampling.keep']).toBe(true);
+    });
+});

--- a/test/tracing/tracing-config.test.ts
+++ b/test/tracing/tracing-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+    setTracingMode,
+    getTracingMode,
+    getEnableSpanLimits,
+    setEnableSpanLimits,
+    maybeWarnLegacy
+} from '../../src/tracing/tracing-config.ts';
+
+describe('Tracing-Config Flags', () => {
+    it('set/getTracingMode', () => {
+        setTracingMode('natural-sync-async');
+        expect(getTracingMode()).toBe('natural-sync-async');
+        setTracingMode('legacy-always-promise');
+        expect(getTracingMode()).toBe('legacy-always-promise');
+    });
+
+    it('Span-Limits Flag togglen', () => {
+        setEnableSpanLimits(false);
+        expect(getEnableSpanLimits()).toBe(false);
+        setEnableSpanLimits(true);
+        expect(getEnableSpanLimits()).toBe(true);
+    });
+
+    it('maybeWarnLegacy - ruft warn jeweils max. 1x pro Thema', () => {
+        const logs: string[] = [];
+        const fakeDiag = {
+            warn: (...a: any[]) => logs.push(a.join(' '))
+        };
+        setTracingMode('legacy-always-promise');
+        setEnableSpanLimits(false);
+
+        maybeWarnLegacy(fakeDiag as any);
+
+        maybeWarnLegacy(fakeDiag as any);
+
+        expect(logs.some((l) => l.includes('Legacy mode active'))).toBe(true);
+        expect(logs.some((l) => l.includes('Span limits are disabled'))).toBe(true);
+
+        const legacyCount = logs.filter((l) => l.includes('Legacy mode active')).length;
+        const limitsCount = logs.filter((l) => l.includes('Span limits are disabled')).length;
+        expect(legacyCount).toBe(1);
+        expect(limitsCount).toBe(1);
+    });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,36 @@
+{
+    "compilerOptions": {
+        "baseUrl": "./",
+        "declaration": true,
+        "declarationMap": false,
+        "outDir": "dist",
+        "lib": ["ES2021", "DOM"],
+        "sourceMap": true,
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strictNullChecks": true,
+        "target": "ES2022",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "removeComments": false,
+        "preserveConstEnums": true,
+        "resolveJsonModule": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "rewriteRelativeImportExtensions": true
+    },
+    "paths": {
+        "tsoa": ["node_modules/tsoa/dist"]
+    },
+    "strict": false,
+    "ts-node": {
+        "swc": true
+    },
+    "plugins": [
+        {
+            "name": "typescript-strict-plugin",
+            "paths": ["./src", "./test"]
+        }
+    ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,11 +1,10 @@
 {
-    "compileOnSave": true,
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "baseUrl": "./",
         "rootDir": "./src",
+        "outDir": "dist",
         "declaration": true,
         "declarationMap": false,
-        "outDir": "dist",
         "lib": ["ES2021", "DOM"],
         "sourceMap": true,
         "module": "NodeNext",
@@ -20,22 +19,15 @@
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,
-        "rewriteRelativeImportExtensions": true,
-        "paths": {
-            "tsoa": ["node_modules/tsoa/dist"]
-        },
-        "strict": false,
-        "plugins": [
-            {
-                "name": "typescript-strict-plugin",
-                "paths:": ["./src", "./test"]
-            }
-        ]
+        "rewriteRelativeImportExtensions": true
     },
+    "paths": {
+        "tsoa": ["node_modules/tsoa/dist"]
+    },
+    "strict": false,
     "ts-node": {
         "swc": true
     },
-
-    "include": ["src/**/*", "build/**/*", "test/**/*"],
-    "exclude": ["node_modules", "**/*.spec.ts"]
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts", "test/**"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node", "vitest"],
+        "rootDir": ".",
+        "experimentalDecorators": true,
+        "allowImportingTsExtensions": true,
+        "plugins": [
+            {
+                "name": "typescript-strict-plugin",
+                "paths": ["./src", "./test"]
+            }
+        ]
+    },
+    "include": ["src/**/*", "test/**/*"],
+    "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+
+        coverage: {
+            provider: 'v8',
+            reportsDirectory: './coverage',
+            reporter: ['text', 'html', 'lcov', 'json-summary'],
+            all: true,
+            include: ['src/**/*.ts'],
+            exclude: ['dist/**', 'src/**/*.d.ts', '**/*.test.ts', 'test/**', '**/__mocks__/**']
+        },
+        projects: [
+            {
+                test: {
+                    name: 'tracing',
+                    setupFiles: ['./test/tracing/setup-otel.ts'],
+                    include: ['test/tracing/**/*.int.test.ts', 'test/tracing/**/*.test.ts'],
+                    exclude: ['test/tracing/instrumentation*.test.ts']
+                }
+            },
+
+            {
+                test: {
+                    name: 'metrics',
+                    include: ['test/metrics/**/*.int.test.ts', 'test/metrics/**/*.test.ts']
+                }
+            },
+
+            {
+                test: {
+                    name: 'init instrumentation',
+                    environment: 'node',
+                    pool: 'forks',
+                    include: ['test/tracing/instrumentation.test.ts']
+                }
+            }
+        ]
+    }
+});


### PR DESCRIPTION
- Tracing:
  - Introduce `startMode` parenting (`reuse` | `createChild` | `newTrace` | `newTraceWithLink`).
  - Add `Traces.getSpan(spanName, options, startMode, moduleName)` (recommended).
  - Support `traceOnlyIf` for conditional tracing:
    - `boolean | (args, thisContext, currentSpan?) => boolean`.
  - **Decorator compatibility (TC39 + legacy):**
    - `Traces.trace(...)` now supports **both** TC39 decorators (`(value, ctx)` for `method/getter/setter/field/auto-accessor`) **and** legacy decorators (`target, key, descriptor`).
    - Preserves `this`-binding and sync/async semantics across all paths.
  - Deprecate `createNewSpan` (use `startMode: 'createChild'`).
  - Deprecate `getCurrentSpanOrCreateNew(...)` (use `getSpan(...)`).

- withTracing behavior:
  - Default “natural” behavior (sync stays sync; async returns Promise).
  - Legacy mode to force Promises for all wrapped calls.

- Metrics:
  - **Decorator compatibility (TC39 + legacy):**
    - `Metrics.counter/gauge/histogram/summary` support TC39 (`method/getter/setter/field/auto-accessor`) and legacy decorator signatures.
  - **Strict lazy creation** preserved (no eager registration).
  - **Robust label handling:**
    - Never leave `labelNames` undefined on registration (at least `[]`).
    - On the **first real measurement** (`inc/set/observe/startTimer`), derive missing `labelNames` from the provided labels (lazy instantiation).
    - Unified boolean conversion (`true|false` → `"true"|"false"`); ignore `undefined` label values.
    - **Filtering:** forward only declared labels to `prom-client` (prevents “Added label … not included …” errors).
    - Safe defaults:
      - Histogram: default buckets when not set.
      - Summary: default percentiles when not set.
  - Internal helpers: `_convertLabels`, `_filterAllowed`, `_ensure*WithLabels` (Counter/Gauge/Histogram/Summary).

- Init / Instrumentation (NEW):
  - **Exporter input** via `exporter`:
    - Accepts a concrete `SpanExporter` instance **or** a descriptor:
      - `{ kind: 'otlp', url: string, concurrencyLimit?: number }`
      - `{ kind: 'console' }`
      - `{ kind: 'noop' }`
  - **Exporter/Processor precedence**:
    1. If **`spanProcessors`** is provided → **use as-is**; no implicit defaults attached.
    2. Else if **`exporter`** is provided → attach **default `BatchSpanProcessor(exporter)`** (except for `noop`, which attaches **no** processors).
    3. Else → run with **no exporter/processors** (no-op exporting).
  - **Legacy flags** maintained (deprecated):
    - `url`, `localDebugging`, `concurrencyLimit` map internally to `exporter` descriptor.
  - **Noop exporter flag**:
    - Internally mark the noop exporter to avoid accidentally attaching a default BSP.
  - **Return shape**:
    - `initInstrumentation(...)` returns `{ sdk, traceExporter, spanProcessors }`.
  - **Shutdown/flush behavior**:
    - `shutDownInstrumentation()` finally disables global tracing/context/propagation.

- Config / Feature flags:
  - `tracingMode`: `'natural-sync-async'` (default) or `'legacy-always-promise'`.
    - Env: `TRACES_MODE` / `TRACES_LEGACY_ASYNC_WRAPPER=1`.
  - Opt-in span limits:
    - Env: `TRACES_ENABLE_LIMITS=1`.
    - Passing `spanLimits` to `initInstrumentation(...)` also enables limits.
    - Defaults when enabled:
      - `attributeValueLengthLimit: 12000`
      - `attributeCountLimit: 128`
      - `eventCountLimit: 128`
      - `linkCountLimit: 128`
      - `attributePerEventCountLimit: 16`
      - `attributePerLinkCountLimit: 16`
  - One-time warnings for legacy mode and when limits are disabled.

- Tests (new):
  - **Tracing:** unit tests for `Traces.trace` covering **TC39 and legacy** decorator paths; `startMode` parenting, `traceOnlyIf`, and status/exception recording.
  - **Init:** tests for `initInstrumentation` covering:
    - exporter/processor precedence,
    - new `exporter` descriptors (`otlp`, `console`, `noop`),
    - concrete `SpanExporter` instance handling,
    - legacy flags (`url`, `localDebugging`, `concurrencyLimit`) back-compat,
    - no-op path (no exporter/processors).
  - **Metrics:** unit tests for registration & lazy creation, label conversion/filtering, and **TC39 + legacy decorator** behavior across `counter/gauge/histogram/summary`.
  - **HTTP metrics e2e:** middleware test with route-pattern labels; module reset before import; counting via sum across histogram `_count` time series.
  - **Facade:** tests for `getMetrics` and delegated metric helpers.

- Docs:
  - Update README.md and docs/tracing.md:
    - Document **exporter/processor precedence** and new `exporter` descriptors.
    - Recommend `startMode` over `createNewSpan`.
    - Recommend `getSpan` over `getCurrentSpanOrCreateNew`.
    - Document `traceOnlyIf` (signature, examples).
    - Document feature flags, defaults, and migration steps.
    - Include `this`-binding and inline lambda examples.

Deprecates: `createNewSpan`, `getCurrentSpanOrCreateNew`, legacy wrapper mode, legacy init flags (`url`, `localDebugging`, `concurrencyLimit`) in favor of `exporter` descriptor.